### PR TITLE
perf: 缓存 QQ 检测结果并减少启动重复探测

### DIFF
--- a/apps/desktop/src/renderer/src/trpc/provider.tsx
+++ b/apps/desktop/src/renderer/src/trpc/provider.tsx
@@ -13,8 +13,15 @@ export function TrpcProvider({ children }: { children: ReactNode }): ReactElemen
     () =>
       new QueryClient({
         defaultOptions: {
-          // Account dbs are read-only after open — refetches just waste time.
-          queries: { staleTime: 5_000 },
+          // Native QQ probes can block the Electron main process briefly.
+          // Avoid re-running them just because the window regains focus.
+          queries: {
+            staleTime: 5 * 60_000,
+            cacheTime: 30 * 60_000,
+            refetchOnMount: false,
+            refetchOnReconnect: false,
+            refetchOnWindowFocus: false,
+          },
         },
       }),
   );

--- a/apps/desktop/src/renderer/src/views/BootstrapView.tsx
+++ b/apps/desktop/src/renderer/src/views/BootstrapView.tsx
@@ -13,7 +13,12 @@ import { useViewState } from '../state/view';
 export function BootstrapView(): ReactElement {
   const install = trpc.bootstrap.describeInstall.useQuery();
   const processes = trpc.bootstrap.detectRunningProcesses.useQuery();
+  trpc.bootstrap.listAccounts.useQuery(undefined, {
+    enabled: !!install.data?.loginDbPath,
+    retry: false,
+  });
   const goTo = useViewState((s) => s.goTo);
+  const preparing = install.isLoading || processes.isLoading;
 
   return (
     <main className="p-6 font-sans leading-relaxed">
@@ -60,9 +65,10 @@ export function BootstrapView(): ReactElement {
 
       <button
         onClick={() => goTo('pick-account')}
-        className="px-6 py-2 bg-primary text-primary-foreground rounded-md shadow-sm hover:opacity-90 transition-opacity"
+        disabled={preparing}
+        className="px-6 py-2 bg-primary text-primary-foreground rounded-md shadow-sm hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
       >
-        去选择账号 →
+        {preparing ? '正在检测…' : '去选择账号 →'}
       </button>
     </main>
   );

--- a/apps/desktop/src/renderer/src/views/PickAccountView.tsx
+++ b/apps/desktop/src/renderer/src/views/PickAccountView.tsx
@@ -26,8 +26,10 @@ import { QrImage } from '../components/QrImage';
 import type { LoginAccount, QqPortLoginInfo } from '@weq/native';
 
 export function PickAccountView(): ReactElement {
-  const accounts = trpc.bootstrap.listAccounts.useQuery();
-  const processes = trpc.bootstrap.detectRunningProcesses.useQuery();
+  const accounts = trpc.bootstrap.listAccounts.useQuery(undefined, { retry: false });
+  const processes = trpc.bootstrap.detectRunningProcesses.useQuery(undefined, {
+    refetchOnMount: false,
+  });
   const [error, setError] = useState<string | null>(null);
   const [obtainedKey, setObtainedKey] = useState<string | null>(null);
   const setOpenedUin = useViewState((s) => s.setOpenedUin);

--- a/packages/service/src/bootstrap/win32_detect.ts
+++ b/packages/service/src/bootstrap/win32_detect.ts
@@ -34,28 +34,62 @@ export interface DetectedQqProcess {
   loginInfo: QqPortLoginInfo | null;
 }
 
+const INSTALL_CACHE_TTL_MS = 5 * 60_000;
+const ACCOUNT_CACHE_TTL_MS = 5 * 60_000;
+const PROCESS_DETECT_CACHE_TTL_MS = 5 * 60_000;
+
 export class Win32DetectService {
+  private installCache:
+    | { readonly expiresAt: number; readonly value: QqInstallInfo }
+    | null = null;
+  private accountCache:
+    | { readonly expiresAt: number; readonly value: LoginAccount[] }
+    | null = null;
+  private processCache:
+    | { readonly expiresAt: number; readonly value: DetectedQqProcess[] }
+    | null = null;
+
   constructor(private readonly platform: Platform) {}
 
   /** Aggregate the static install / data paths the UI's "diagnostics" screen wants. */
   describeInstall(): QqInstallInfo {
-    return {
+    const now = Date.now();
+    if (this.installCache && this.installCache.expiresAt > now) {
+      return this.installCache.value;
+    }
+
+    const value = {
       qqExePath: this.platform.qqExePath(),
       wrapperNodePath: this.platform.qqWrapperNodePath(),
       tencentFilesRoots: this.platform.tencentFilesRoots().filter((p) => existsSync(p)),
       loginDbPath: this.platform.loginDbPath(),
     };
+    this.installCache = {
+      expiresAt: now + INSTALL_CACHE_TTL_MS,
+      value,
+    };
+    return value;
   }
 
   /** All historically-cached accounts from `login.db`. Throws if the DB is missing. */
   listAccounts(): LoginAccount[] {
+    const now = Date.now();
+    if (this.accountCache && this.accountCache.expiresAt > now) {
+      return this.accountCache.value;
+    }
+
     const dbPath = this.platform.loginDbPath();
     if (!dbPath) {
       throw new Error(
         'login.db not found in any candidate Tencent Files root. Is QQ NT installed?',
       );
     }
-    return this.platform.native.ntHelper.decryptLoginDb(dbPath);
+    const value = this.platform.native.ntHelper.decryptLoginDb(dbPath);
+    this.accountCache = {
+      expiresAt: now + ACCOUNT_CACHE_TTL_MS,
+      value,
+    };
+    return value;
   }
 
   /**
@@ -64,14 +98,21 @@ export class Win32DetectService {
    * you want to pull a key from?".
    */
   detectRunningProcesses(): DetectedQqProcess[] {
-    const pids = this.platform.native.ntHelper.getQqProcesses();
-    for (const pid of pids) {
-      console.log(this.platform.native.ntHelper.probeQqLoginInfo(pid));
+    const now = Date.now();
+    if (this.processCache && this.processCache.expiresAt > now) {
+      return this.processCache.value;
     }
-    return pids.map((pid) => ({
+
+    const pids = this.platform.native.ntHelper.getQqProcesses();
+    const value = pids.map((pid) => ({
       pid,
       loginInfo: this.platform.native.ntHelper.probeQqLoginInfo(pid),
     }));
+    this.processCache = {
+      expiresAt: now + PROCESS_DETECT_CACHE_TTL_MS,
+      value,
+    };
+    return value;
   }
 
   /** Convenience: per-account `nt_msg.db` lookup with a clean error. */


### PR DESCRIPTION
- 为 Windows QQ 安装信息、账号列表、运行进程检测增加 5 分钟缓存
- 移除进程检测中的重复 probe 调试输出，避免额外 native 调用
- 调整 React Query 默认缓存策略，避免窗口聚焦、重连、挂载时重复触发检测
- 启动页提前预热账号列表，并在检测中禁用“去选择账号”按钮
- 账号选择页关闭账号列表重试和进程检测挂载刷新，降低主进程阻塞风险