### PR TITLE
新增本地离线数据库读取，新增初始界面的关闭按钮

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Auto-detect text files and normalize line endings to LF on commit
+* text=auto
+
+# Source code
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+*.css text eol=lf
+*.html text eol=lf
+*.md text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.toml text eol=lf
+
+# Native / binary
+*.node binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff2 binary
+*.ttf binary
+*.dll binary
+*.exe binary

--- a/apps/desktop/src/main/context/app_context.ts
+++ b/apps/desktop/src/main/context/app_context.ts
@@ -60,7 +60,7 @@ import {
   type DbChange,
   type DbHealthFailure,
 } from '@weq/service';
-import { openAccount, type AccountContext, type AccountSession } from '@weq/account';
+import { openAccount, openStaticAccount, type AccountContext, type AccountSession } from '@weq/account';
 
 /**
  * Process-wide bus for nt_msg.db changes, fed by the single `dbWatch` loop
@@ -240,6 +240,8 @@ export interface AppContext {
   scheduler: import('@weq/service').ExportScheduler | null;
   /** Open (or re-open) an account session. Disposes the previous one first. */
   setAccount(ctx: AccountContext, metadata?: AccountConfigMetadata): Promise<void>;
+  /** Open a static (offline) account from a directory of plain decrypted databases. */
+  setStaticAccount(dirPath: string): Promise<void>;
   /** Drop the current account session, if any. */
   clearAccount(): void;
   /**
@@ -274,6 +276,9 @@ export function initAppContext(): AppContext {
       scheduler: null,
       setAccount(): Promise<void> {
         throw new Error('native bundle failed to load — cannot open an account');
+      },
+      setStaticAccount(): Promise<void> {
+        throw new Error('native bundle failed to load — cannot open a static account');
       },
       clearAccount(): void {
         /* nothing to clear */
@@ -475,6 +480,127 @@ export function initAppContext(): AppContext {
         mountDbWatch(session);
       }
       setTimeout(() => startDbHealthCheck(this, session, platform), 0);
+    },
+    async setStaticAccount(dirPath: string): Promise<void> {
+      dbHealthCheckSeq += 1;
+      accountMonitor?.stop();
+      accountMonitor = null;
+      this.account?.dispose();
+      dbWatchHandle?.unmount();
+      dbWatchHandle = null;
+      this.scheduler?.stop();
+      this.scheduler = null;
+
+      const session = await openStaticAccount(platform, dirPath);
+      this.account = session;
+
+      const accountConfig = new AccountConfigService(session, platform.appDataRoot());
+      const exportConfigId = accountConfigId(session.context.uin, dirPath);
+
+      // Live QQ is not available for static accounts — PID-dependent services
+      // will simply fail gracefully when called.
+      const noPid = (): number => {
+        throw new Error('QQ account is not online (static account — offline mode).');
+      };
+
+      const mediaDownload = new MediaDownloadService(
+        accountConfig,
+        userConfig.cacheDir('media'),
+      );
+      const mediaUrl = new MediaUrlService(platform.native.ntHelper, session, noPid);
+      const groupInfo = new GroupInfoService(session);
+      const profile = new ProfileService(session);
+
+      this.services = {
+        msgs: new MsgService(session),
+        recentContacts: new RecentContactService(session),
+        unreadInfo: new UnreadInfoService(session),
+        accountConfig,
+        forwardMsgs: new ForwardMsgService(session),
+        groupInfo,
+        groupNotify: new GroupNotifyService(session),
+        profile,
+        msgSearch: new MsgSearchService(session),
+        onlineStatus: new OnlineStatusService(session),
+        fileSearch: new FileSearchService(session, platform),
+        mediaDownload,
+        fileAssistant: new FileAssistantService(session),
+        emoji: new EmojiService(session, platform),
+        exportManager: new (await import('@weq/service')).ExportTaskManager(
+          new MsgService(session),
+          userConfig.cacheDir(join('export', exportConfigId)),
+          {
+            avatarCache: bootstrap.avatarCache,
+            mediaDownload,
+            mediaUrl,
+            // For static accounts, the data directory IS the decrypted DB
+            // directory. nt_data media subdirectories won't be present, so
+            // media-copy will skip gracefully and only CDN completion would
+            // work (which requires a live QQ — unavailable here).
+            accountDir: dirPath,
+            decodeSilk: (silk: string, dest: string) =>
+              import('../voice').then((m) => m.decodeSilkToFile(silk, dest)),
+            transcribe: async (silkPath: string) => {
+              const modelId = userConfig.getSettings().voiceTranscribe.modelId;
+              if (!modelId) return { ok: false, error: '未选择转录模型' };
+              const model = getVoiceModel(modelId);
+              if (!model) return { ok: false, error: '转录模型不存在' };
+              const status = bootstrap.voiceTranscribe.getModelStatus(modelId);
+              if (!status?.downloaded) return { ok: false, error: '转录模型未下载' };
+              const { decodeSilkToWav16kBuffer } = await import('../voice');
+              const wav = await decodeSilkToWav16kBuffer(silkPath);
+              if (!wav) return { ok: false, error: '语音解码失败' };
+              const paths = bootstrap.voiceTranscribe.resolveModelPaths(modelId);
+              if (!paths.model || !paths.tokens) return { ok: false, error: '模型文件缺失' };
+              const { transcribeWav } = await import('../transcribe/engine');
+              const r = await transcribeWav(
+                wav,
+                { model: paths.model, tokens: paths.tokens },
+                { engine: model.engine, languages: model.languages },
+              );
+              return r.success
+                ? { ok: true, text: r.text ?? '' }
+                : { ok: false, error: r.error ?? '识别失败' };
+            },
+            chatlab: {
+              resolveGroupMembers: async (groupCode, uids) => {
+                const members = await groupInfo.getMembersByUids(BigInt(groupCode), uids);
+                return members.map((m) => ({
+                  uid: m.uid,
+                  uin: m.uin.toString(),
+                  card: m.card,
+                  nick: m.nick,
+                  adminFlag: m.adminFlag,
+                }));
+              },
+              groupMeta: async (groupCode) => {
+                const detail = await groupInfo.getGroupDetail(BigInt(groupCode));
+                return detail ? { name: detail.groupName, ownerUid: detail.ownerUid } : null;
+              },
+              resolveProfile: async (uid) => {
+                const p = await profile.getProfile(uid);
+                return p ? { uin: p.uin.toString(), nick: p.nick } : null;
+              },
+              self: async () => {
+                const p = await profile.getSelfProfile();
+                if (p) return { uid: p.uid, uin: p.uin.toString(), nick: p.nick };
+                const uin = String(session.context.uin ?? '');
+                return uin ? { uid: '', uin, nick: '' } : null;
+              },
+            },
+          },
+        ),
+        dbDecrypt: new DbDecryptService(session, platform),
+        webQuery: new WebQueryService(platform.native.ntHelper, session, noPid),
+        groupAlbumMedia: new GroupAlbumMediaService(platform.native.ntHelper, session, noPid),
+      };
+
+      // Persist metadata keyed by the decrypted-db directory, so re-opening
+      // works without re-selecting the folder.
+      accountConfig.save({ dataDir: dirPath });
+
+      // No monitor, no db watch, no health check, no scheduler —
+      // static accounts are offline snapshots.
     },
     clearAccount(): void {
       dbHealthCheckSeq += 1;

--- a/apps/desktop/src/main/context/app_context.ts
+++ b/apps/desktop/src/main/context/app_context.ts
@@ -60,7 +60,7 @@ import {
   type DbChange,
   type DbHealthFailure,
 } from '@weq/service';
-import { openAccount, openStaticAccount, type AccountContext, type AccountSession } from '@weq/account';
+import { openAccount, openStaticAccount, peekStaticSelfUin, type AccountContext, type AccountSession } from '@weq/account';
 
 /**
  * Process-wide bus for nt_msg.db changes, fed by the single `dbWatch` loop
@@ -240,8 +240,18 @@ export interface AppContext {
   scheduler: import('@weq/service').ExportScheduler | null;
   /** Open (or re-open) an account session. Disposes the previous one first. */
   setAccount(ctx: AccountContext, metadata?: AccountConfigMetadata): Promise<void>;
-  /** Open a static (offline) account from a directory of plain decrypted databases. */
-  setStaticAccount(dirPath: string): Promise<void>;
+  /**
+   * Open a static (offline) account from a directory of locally-stored
+   * databases. Pass `selfPreview` (from `peekStaticSelfUin`) so we don't
+   * have to trust the directory name as the UIN. Optional `dbKey` +
+   * `algo` are for still-encrypted SQLCipher backups; omit them for
+   * already-decrypted plain SQLite folders.
+   */
+  setStaticAccount(
+    dirPath: string,
+    selfPreview: { uin: string; displayName: string; avatarUrl: string },
+    options?: { dbKey?: string; algo?: import('@weq/native').DatabaseAlgorithms },
+  ): Promise<void>;
   /** Drop the current account session, if any. */
   clearAccount(): void;
   /**
@@ -481,7 +491,11 @@ export function initAppContext(): AppContext {
       }
       setTimeout(() => startDbHealthCheck(this, session, platform), 0);
     },
-    async setStaticAccount(dirPath: string): Promise<void> {
+    async setStaticAccount(
+      dirPath: string,
+      selfPreview: { uin: string; displayName: string; avatarUrl: string },
+      options: { dbKey?: string; algo?: import('@weq/native').DatabaseAlgorithms } = {},
+    ): Promise<void> {
       dbHealthCheckSeq += 1;
       accountMonitor?.stop();
       accountMonitor = null;
@@ -491,7 +505,12 @@ export function initAppContext(): AppContext {
       this.scheduler?.stop();
       this.scheduler = null;
 
-      const session = await openStaticAccount(platform, dirPath);
+      const session = await openStaticAccount(platform, {
+        dirPath,
+        self: { uin: selfPreview.uin, nick: selfPreview.displayName, avatarUrl: selfPreview.avatarUrl, uid: '' },
+        ...(options.dbKey ? { dbKey: options.dbKey } : {}),
+        ...(options.algo ? { algo: options.algo } : {}),
+      });
       this.account = session;
 
       const accountConfig = new AccountConfigService(session, platform.appDataRoot());
@@ -596,8 +615,14 @@ export function initAppContext(): AppContext {
       };
 
       // Persist metadata keyed by the decrypted-db directory, so re-opening
-      // works without re-selecting the folder.
-      accountConfig.save({ dataDir: dirPath });
+      // works without re-selecting the folder. `static: true` is the marker
+      // the account-list badge + re-open path look for.
+      accountConfig.save({
+        dataDir: dirPath,
+        static: true,
+        ...(selfPreview.displayName ? { displayName: selfPreview.displayName } : {}),
+        ...(selfPreview.avatarUrl ? { avatarUrl: selfPreview.avatarUrl } : {}),
+      });
 
       // No monitor, no db watch, no health check, no scheduler —
       // static accounts are offline snapshots.

--- a/apps/desktop/src/main/ipc/routers/bootstrap.ts
+++ b/apps/desktop/src/main/ipc/routers/bootstrap.ts
@@ -316,6 +316,15 @@ export const bootstrapRouter = router({
     return result.filePaths[0] ?? null;
   }),
 
+  pickStaticDbDir: procedure.mutation(async () => {
+    const result = await dialog.showOpenDialog({
+      title: '选择已解密的 QQ 数据库目录',
+      properties: ['openDirectory'],
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+    return result.filePaths[0] ?? null;
+  }),
+
   // ---- key correctness probe ----
 
   /**
@@ -497,6 +506,28 @@ export const bootstrapRouter = router({
     getAppContext().clearAccount();
     return true;
   }),
+
+  // ---- static (offline) account from decrypted local databases ----
+
+  /**
+   * Open a static account from a directory of already-decrypted plain-SQLite
+   * QQ databases. The directory name is used as the account UIN. No dbKey or
+   * live QQ is required — all features work in offline/static mode.
+   */
+  openStaticAccount: procedure
+    .input(z.object({ dirPath: z.string().min(1) }))
+    .mutation(async ({ input }) => {
+      const ctx = getAppContext();
+      if (!existsSync(input.dirPath)) {
+        throw new Error(`Directory not found: ${input.dirPath}`);
+      }
+      const ntMsgPath = join(input.dirPath, 'nt_msg.db');
+      if (!existsSync(ntMsgPath)) {
+        throw new Error(`nt_msg.db not found in selected directory: ${input.dirPath}`);
+      }
+      await ctx.setStaticAccount(input.dirPath);
+      return ctx.account!.context;
+    }),
 
   /** True if an account session is currently open. */
   accountOpen: procedure.query(() => {

--- a/apps/desktop/src/main/ipc/routers/bootstrap.ts
+++ b/apps/desktop/src/main/ipc/routers/bootstrap.ts
@@ -27,6 +27,7 @@ import {
 } from '../../context/app_context';
 import { procedure, router } from '../trpc';
 import { accountConfigId, type KeyEvent, type VoiceDownloadProgress } from '@weq/service';
+import { peekStaticSelfUin } from '@weq/account';
 
 const algoSchema = z.object({
   pageHmacAlgorithm: z.string(),
@@ -507,25 +508,98 @@ export const bootstrapRouter = router({
     return true;
   }),
 
-  // ---- static (offline) account from decrypted local databases ----
+  // ---- static (offline) account from local databases ----
 
   /**
-   * Open a static account from a directory of already-decrypted plain-SQLite
-   * QQ databases. The directory name is used as the account UIN. No dbKey or
-   * live QQ is required — all features work in offline/static mode.
+   * Probe a directory of local QQ databases. Tries to read the self row
+   * from `profile_info_v6` so the UI can show the resolved UIN / nickname
+   * before committing to an open.
+   *
+   *   - No key, plain SQLite succeeds → returns `{ ok: true, needKey: false, preview }`
+   *   - SQLCipher with correct key    → same
+   *   - SQLCipher without key (or wrong key) → `{ ok: true, needKey: true }`
+   *     (needKey=true is not a hard error; the UI then prompts for a key)
+   *   - Missing files / corrupt db   → `{ ok: false, error }`
+   */
+  testStaticDir: procedure
+    .input(
+      z.object({
+        dirPath: z.string().min(1),
+        dbKey: z.string().optional(),
+        algo: algoSchema.optional(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const platform = requirePlatform();
+      if (!existsSync(input.dirPath)) {
+        return { ok: false as const, error: `目录不存在：${input.dirPath}` };
+      }
+      const profileInfoPath = join(input.dirPath, 'profile_info.db');
+      const ntMsgPath = join(input.dirPath, 'nt_msg.db');
+      if (!existsSync(profileInfoPath)) {
+        return { ok: false as const, error: '未在所选目录中找到 profile_info.db' };
+      }
+      if (!existsSync(ntMsgPath)) {
+        return { ok: false as const, error: '未在所选目录中找到 nt_msg.db' };
+      }
+      try {
+        const preview = await peekStaticSelfUin(
+          platform,
+          input.dirPath,
+          input.dbKey,
+          input.algo,
+        );
+        return {
+          ok: true as const,
+          needKey: false as const,
+          preview: {
+            uin: preview.uin,
+            displayName: preview.nick,
+            avatarUrl: preview.avatarUrl,
+          },
+        };
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        // Caller didn't supply a key — ask for one. NOT a hard error.
+        if (!input.dbKey) {
+          return { ok: true as const, needKey: true as const };
+        }
+        return { ok: false as const, error: `无法打开数据库：${msg}` };
+      }
+    }),
+
+  /**
+   * Open a static (offline) account. The caller must have already resolved
+   * a self preview (UIN + nick) via `testStaticDir`; we don't trust the
+   * directory name as a UIN. `dbKey` is required for SQLCipher backups;
+   * omit it for already-decrypted plain SQLite folders.
    */
   openStaticAccount: procedure
-    .input(z.object({ dirPath: z.string().min(1) }))
+    .input(
+      z.object({
+        dirPath: z.string().min(1),
+        dbKey: z.string().optional(),
+        algo: algoSchema.optional(),
+        preview: z.object({
+          uin: z.string().min(1),
+          displayName: z.string(),
+          avatarUrl: z.string(),
+        }),
+      }),
+    )
     .mutation(async ({ input }) => {
       const ctx = getAppContext();
       if (!existsSync(input.dirPath)) {
-        throw new Error(`Directory not found: ${input.dirPath}`);
+        throw new Error(`目录不存在：${input.dirPath}`);
       }
       const ntMsgPath = join(input.dirPath, 'nt_msg.db');
       if (!existsSync(ntMsgPath)) {
-        throw new Error(`nt_msg.db not found in selected directory: ${input.dirPath}`);
+        throw new Error(`未在所选目录中找到 nt_msg.db：${input.dirPath}`);
       }
-      await ctx.setStaticAccount(input.dirPath);
+      await ctx.setStaticAccount(input.dirPath, input.preview, {
+        ...(input.dbKey ? { dbKey: input.dbKey } : {}),
+        ...(input.algo ? { algo: input.algo } : {}),
+      });
       return ctx.account!.context;
     }),
 

--- a/apps/desktop/src/renderer/src/components/RailAccountFooter.tsx
+++ b/apps/desktop/src/renderer/src/components/RailAccountFooter.tsx
@@ -105,6 +105,7 @@ export function RailAccountFooter({
     displayName?: string;
     avatarUrl?: string | null;
     dataDir?: string;
+    static?: boolean;
   }): Promise<void> {
     if (busy) return;
     if (cfg.uin === currentUin) return;
@@ -118,14 +119,30 @@ export function RailAccountFooter({
       purgeAccountCache();
       setOpenedUin(null);
       await new Promise((resolve) => setTimeout(resolve, 0));
-      await client.bootstrap.openAccount.mutate({
-        uin: cfg.uin,
-        dbKey: cfg.dbKey,
-        ...(cfg.algo ? { algo: cfg.algo } : {}),
-        ...(cfg.displayName ? { displayName: cfg.displayName } : {}),
-        ...(cfg.avatarUrl ? { avatarUrl: cfg.avatarUrl } : {}),
-        ...(cfg.dataDir ? { dataDir: cfg.dataDir } : {}),
-      });
+      if (cfg.static) {
+        // Static (offline) account — no live key gate; re-open from its
+        // saved decrypted-db directory.
+        if (!cfg.dataDir) throw new Error('该静态账号缺少数据库目录，请重新导入。');
+        await client.bootstrap.openStaticAccount.mutate({
+          dirPath: cfg.dataDir,
+          preview: {
+            uin: cfg.uin,
+            displayName: cfg.displayName ?? '',
+            avatarUrl: cfg.avatarUrl ?? '',
+          },
+          ...(cfg.dbKey ? { dbKey: cfg.dbKey } : {}),
+          ...(cfg.algo?.pageHmacAlgorithm ? { algo: cfg.algo } : {}),
+        });
+      } else {
+        await client.bootstrap.openAccount.mutate({
+          uin: cfg.uin,
+          dbKey: cfg.dbKey,
+          ...(cfg.algo ? { algo: cfg.algo } : {}),
+          ...(cfg.displayName ? { displayName: cfg.displayName } : {}),
+          ...(cfg.avatarUrl ? { avatarUrl: cfg.avatarUrl } : {}),
+          ...(cfg.dataDir ? { dataDir: cfg.dataDir } : {}),
+        });
+      }
       // Second purge: anything an in-flight component re-issued between the
       // first purge and openAccount completion (e.g. a useQuery refetch
       // triggered by the unmount/remount transition) would have hit the

--- a/apps/desktop/src/renderer/src/styles/index.css
+++ b/apps/desktop/src/renderer/src/styles/index.css
@@ -263,6 +263,10 @@
     background: rgba(0, 153, 255, 0.18);
   }
 
+  .weq-shell-close-btn {
+    -webkit-app-region: no-drag;
+  }
+
   .weq-icon-button,
   .weq-danger-button,
   .weq-action-primary,
@@ -1134,6 +1138,11 @@
     border-color: rgba(0, 153, 255, 0.5);
     background: linear-gradient(150deg, rgba(0, 153, 255, 0.12), rgba(83, 206, 144, 0.08));
   }
+  .weq-entry-card.is-static {
+    grid-column: 1 / -1;
+    border-color: rgba(139, 92, 246, 0.35);
+    background: linear-gradient(150deg, rgba(139, 92, 246, 0.06), rgba(236, 72, 153, 0.03));
+  }
   .weq-entry-icon {
     display: inline-flex;
     width: 2.7rem;
@@ -1148,6 +1157,10 @@
   .weq-entry-card.is-primary .weq-entry-icon {
     color: #ffffff;
     background: linear-gradient(140deg, #0aa2ff, #36c08f);
+  }
+  .weq-entry-icon.is-static {
+    color: #ffffff;
+    background: linear-gradient(140deg, #8b5cf6, #ec4899);
   }
   .weq-entry-text { display: flex; flex-direction: column; gap: 0.18rem; min-width: 0; }
   .weq-entry-title { font-size: 15px; font-weight: 600; color: #11304d; }

--- a/apps/desktop/src/renderer/src/styles/index.css
+++ b/apps/desktop/src/renderer/src/styles/index.css
@@ -1138,11 +1138,6 @@
     border-color: rgba(0, 153, 255, 0.5);
     background: linear-gradient(150deg, rgba(0, 153, 255, 0.12), rgba(83, 206, 144, 0.08));
   }
-  .weq-entry-card.is-static {
-    grid-column: 1 / -1;
-    border-color: rgba(139, 92, 246, 0.35);
-    background: linear-gradient(150deg, rgba(139, 92, 246, 0.06), rgba(236, 72, 153, 0.03));
-  }
   .weq-entry-icon {
     display: inline-flex;
     width: 2.7rem;
@@ -1157,10 +1152,6 @@
   .weq-entry-card.is-primary .weq-entry-icon {
     color: #ffffff;
     background: linear-gradient(140deg, #0aa2ff, #36c08f);
-  }
-  .weq-entry-icon.is-static {
-    color: #ffffff;
-    background: linear-gradient(140deg, #8b5cf6, #ec4899);
   }
   .weq-entry-text { display: flex; flex-direction: column; gap: 0.18rem; min-width: 0; }
   .weq-entry-title { font-size: 15px; font-weight: 600; color: #11304d; }
@@ -1186,6 +1177,11 @@
   .weq-select-head-drag {
     flex: 1;
     align-self: stretch;
+    /* Leave room at the right for the Shell's close (X) button — Electron's
+       drag-region hit test runs outside the compositor stack, so a `drag`
+       region painted under the X still swallows its clicks. Carve out a
+       no-drag gap the width of the button + its inset. */
+    margin-right: 3rem;
     -webkit-app-region: drag;
   }
   .weq-select-head button { -webkit-app-region: no-drag; }
@@ -1232,6 +1228,187 @@
     flex-direction: column;
     gap: 1.1rem;
   }
+
+  /* ---- source tabs (新的开始: 在线账号 / 本地备份) ---- */
+  .weq-source-tabs {
+    display: inline-flex;
+    align-self: center;
+    gap: 0.18rem;
+    padding: 0.18rem;
+    border-radius: 9px;
+    border: 1px solid rgba(0, 153, 255, 0.16);
+    background: rgba(0, 153, 255, 0.04);
+  }
+  .weq-source-tab {
+    padding: 0.3rem 0.85rem;
+    border-radius: 7px;
+    font-size: 13px !important;
+    font-weight: 500;
+    color: #5a6f84;
+    transition: background-color 140ms ease, color 140ms ease, box-shadow 140ms ease;
+  }
+  .weq-source-tab:hover {
+    color: #16344f;
+  }
+  .weq-source-tab.is-active {
+    color: #0a4d80;
+    background: #ffffff;
+    box-shadow: 0 2px 8px -3px rgba(7, 31, 61, 0.28);
+  }
+
+  /* ---- static backup import panel ---- */
+  .weq-static-backup {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+  .weq-static-backup-head {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.5rem 0 0.25rem;
+  }
+  .weq-static-backup-logo {
+    border-radius: 999px;
+    object-fit: contain;
+    padding: 1.4rem;
+    background: rgba(255, 255, 255, 0.7);
+    border: 3px solid rgba(255, 255, 255, 0.95);
+    box-shadow: 0 16px 34px -16px rgba(139, 92, 246, 0.45);
+  }
+  .weq-static-backup-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: #11304d;
+  }
+  .weq-static-help {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.6rem 0.75rem;
+    border-radius: 0.6rem;
+    border: 1px solid rgba(139, 92, 246, 0.22);
+    background: linear-gradient(150deg, rgba(139, 92, 246, 0.07), rgba(236, 72, 153, 0.035));
+    font-size: 11.5px;
+    line-height: 1.5;
+    color: #5a4b7a;
+  }
+  .weq-static-help svg {
+    flex-shrink: 0;
+    margin-top: 0.05rem;
+    color: #8b5cf6;
+  }
+  .weq-static-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .weq-static-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 12px;
+    font-weight: 600;
+    color: #11304d;
+  }
+  .weq-static-label svg {
+    color: #0099ff;
+  }
+  .weq-static-inputwrap {
+    display: flex;
+    gap: 0.5rem;
+  }
+  .weq-static-input {
+    flex: 1;
+    min-width: 0;
+    height: 2.5rem;
+    padding: 0 0.7rem;
+    border-radius: 0.6rem;
+    border: 1px solid rgba(0, 153, 255, 0.26);
+    background: rgba(255, 255, 255, 0.55);
+    font-size: 12px !important;
+    color: #142235;
+    transition: border-color 150ms ease, box-shadow 150ms ease;
+  }
+  .weq-static-input:focus {
+    outline: none;
+    border-color: rgba(0, 153, 255, 0.6);
+    box-shadow: 0 0 0 3px rgba(0, 153, 255, 0.1);
+  }
+  .weq-static-input::placeholder {
+    color: #7589a0;
+  }
+  .weq-static-input.is-error {
+    border-color: rgba(220, 70, 70, 0.55);
+    background: rgba(220, 70, 70, 0.04);
+  }
+  .weq-static-inputwrap .weq-action-primary {
+    height: 2.5rem;
+    padding-inline: 1rem;
+    font-size: 12px !important;
+    flex-shrink: 0;
+  }
+  .weq-static-hint {
+    font-size: 11px;
+    color: #8b6f9a;
+  }
+  .weq-static-actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+  .weq-static-actions .weq-action-primary {
+    height: 2.5rem;
+    padding-inline: 1rem;
+    font-size: 12px !important;
+  }
+  .weq-static-backup-avatar-wrap {
+    position: relative;
+    display: inline-flex;
+  }
+  .weq-static-enter {
+    width: 100%;
+    height: 2.5rem;
+    font-size: 12px !important;
+  }
+  .weq-static-error {
+    padding: 0.55rem 0.75rem;
+    border-radius: 0.6rem;
+    border: 1px solid rgba(220, 70, 70, 0.35);
+    background: rgba(220, 70, 70, 0.05);
+    font-size: 12px;
+    color: #b23a3a;
+  }
+
+  /* ---- static account badge (avatar corner, account list) ---- */
+  .weq-acct-row-avatar-wrap {
+    position: relative;
+    display: inline-flex;
+    flex-shrink: 0;
+  }
+  .weq-static-badge {
+    position: absolute;
+    right: -2px;
+    bottom: -2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #ffffff;
+    background: linear-gradient(140deg, #8b5cf6, #ec4899);
+    box-shadow: 0 0 0 2px #ffffff;
+  }
+  /* Larger corner badge for the 140px header avatars (selector + backup panel). */
+  .weq-static-badge.is-lg {
+    width: 30px;
+    height: 30px;
+    right: 6px;
+    bottom: 6px;
+    box-shadow: 0 0 0 3px #ffffff;
+  }
+
   .weq-login-status {
     display: inline-flex;
     align-self: center;

--- a/apps/desktop/src/renderer/src/views/BootstrapView.tsx
+++ b/apps/desktop/src/renderer/src/views/BootstrapView.tsx
@@ -13,7 +13,7 @@
  */
 
 import { useEffect, useRef, type ReactElement, type ReactNode } from 'react';
-import { Loader2 } from 'lucide-react';
+import { Loader2, X } from 'lucide-react';
 import { trpc, client } from '../trpc/client';
 import { useViewState } from '../state/view';
 import { useDialog } from '../components/Dialog';
@@ -164,12 +164,28 @@ export function BootstrapView(): ReactElement {
     );
   }
 
+  async function handleStatic(): Promise<void> {
+    try {
+      const dirPath = await client.bootstrap.pickStaticDbDir.mutate();
+      if (!dirPath) return;
+      await client.bootstrap.openStaticAccount.mutate({ dirPath });
+      // Derive the UIN from the directory name for the main view.
+      const uin = dirPath.split(/[/\\]/).pop() ?? '';
+      setHomeStage('home');
+      setOpenedUin(uin);
+      goTo('main');
+    } catch (e) {
+      showError('打开本地数据库失败', errMsg(e));
+    }
+  }
+
   return (
     <Shell>
       <HomeScreen
         hasConfigs={(configs.data?.length ?? 0) > 0}
         onExisting={() => enterSelect('existing')}
         onNew={() => enterSelect('new')}
+        onStatic={() => void handleStatic()}
       />
     </Shell>
   );
@@ -178,6 +194,14 @@ export function BootstrapView(): ReactElement {
 function Shell({ children }: { children: ReactNode }): ReactElement {
   return (
     <main className="weq-home-shell h-screen overflow-hidden font-sans text-[#142235]">
+      <button
+        type="button"
+        className="weq-shell-close-btn absolute right-4 top-4 z-20 flex h-8 w-8 items-center justify-center rounded-full text-[#7a8b9e] transition-colors hover:bg-black/5 hover:text-[#142235]"
+        onClick={() => window.close()}
+        aria-label="关闭"
+      >
+        <X size={18} strokeWidth={1.8} />
+      </button>
       <div className="relative z-10 h-full">{children}</div>
     </main>
   );

--- a/apps/desktop/src/renderer/src/views/BootstrapView.tsx
+++ b/apps/desktop/src/renderer/src/views/BootstrapView.tsx
@@ -93,16 +93,32 @@ export function BootstrapView(): ReactElement {
 
     void (async () => {
       try {
-        const test = await client.bootstrap.testDatabaseKey.mutate({ uin: cfg.uin, dbKey: cfg.dbKey });
-        if (!test.success) throw new Error(test.error ?? '数据库密钥不正确');
-        await client.bootstrap.openAccount.mutate({
-          uin: cfg.uin,
-          dbKey: cfg.dbKey,
-          algo: test.algo,
-          ...(cfg.displayName ? { displayName: cfg.displayName } : {}),
-          ...(cfg.avatarUrl ? { avatarUrl: cfg.avatarUrl } : {}),
-          ...(cfg.dataDir ? { dataDir: cfg.dataDir } : {}),
-        });
+        if (cfg.static) {
+          // Static (offline) account — no live key gate; re-open from its
+          // saved decrypted-db directory.
+          if (!cfg.dataDir) throw new Error('该静态账号缺少数据库目录，请重新导入。');
+          await client.bootstrap.openStaticAccount.mutate({
+            dirPath: cfg.dataDir,
+            preview: {
+              uin: cfg.uin,
+              displayName: cfg.displayName ?? '',
+              avatarUrl: cfg.avatarUrl ?? '',
+            },
+            ...(cfg.dbKey ? { dbKey: cfg.dbKey } : {}),
+            ...(cfg.algo?.pageHmacAlgorithm ? { algo: cfg.algo } : {}),
+          });
+        } else {
+          const test = await client.bootstrap.testDatabaseKey.mutate({ uin: cfg.uin, dbKey: cfg.dbKey });
+          if (!test.success) throw new Error(test.error ?? '数据库密钥不正确');
+          await client.bootstrap.openAccount.mutate({
+            uin: cfg.uin,
+            dbKey: cfg.dbKey,
+            algo: test.algo,
+            ...(cfg.displayName ? { displayName: cfg.displayName } : {}),
+            ...(cfg.avatarUrl ? { avatarUrl: cfg.avatarUrl } : {}),
+            ...(cfg.dataDir ? { dataDir: cfg.dataDir } : {}),
+          });
+        }
         // Land on 'home' so closing the account later returns to the landing
         // screen rather than re-running the (now consumed) boot splash.
         setHomeStage('home');
@@ -164,28 +180,12 @@ export function BootstrapView(): ReactElement {
     );
   }
 
-  async function handleStatic(): Promise<void> {
-    try {
-      const dirPath = await client.bootstrap.pickStaticDbDir.mutate();
-      if (!dirPath) return;
-      await client.bootstrap.openStaticAccount.mutate({ dirPath });
-      // Derive the UIN from the directory name for the main view.
-      const uin = dirPath.split(/[/\\]/).pop() ?? '';
-      setHomeStage('home');
-      setOpenedUin(uin);
-      goTo('main');
-    } catch (e) {
-      showError('打开本地数据库失败', errMsg(e));
-    }
-  }
-
   return (
     <Shell>
       <HomeScreen
         hasConfigs={(configs.data?.length ?? 0) > 0}
         onExisting={() => enterSelect('existing')}
         onNew={() => enterSelect('new')}
-        onStatic={() => void handleStatic()}
       />
     </Shell>
   );

--- a/apps/desktop/src/renderer/src/views/bootstrap/AccountSelector.tsx
+++ b/apps/desktop/src/renderer/src/views/bootstrap/AccountSelector.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useEffect, useLayoutEffect, useRef, useState, type ReactElement, type ReactNode } from 'react';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, Database } from 'lucide-react';
 import { QqAvatar } from '../../components/QqAvatar';
 import type { UiAccount } from './types';
 
@@ -82,7 +82,14 @@ export function AccountSelector({
 
   return (
     <div className="weq-acct" ref={ref}>
-      <QqAvatar uin={selected?.uin} url={selected?.avatarUrl} size={140} className="weq-acct-avatar" />
+      <span className="weq-static-backup-avatar-wrap">
+        <QqAvatar uin={selected?.uin} url={selected?.avatarUrl} size={140} className="weq-acct-avatar" />
+        {selected?.static && (
+          <span className="weq-static-badge is-lg" title="静态离线账号" aria-label="静态离线账号">
+            <Database size={13} strokeWidth={2.2} aria-hidden />
+          </span>
+        )}
+      </span>
 
       <div className="weq-acct-id">
         <div className={selected?.hasName ? 'weq-acct-name' : 'weq-acct-name weq-acct-name-strong'}>
@@ -123,7 +130,14 @@ export function AccountSelector({
                         setOpen(false);
                       }}
                     >
-                      <QqAvatar uin={acc.uin} url={acc.avatarUrl} size={38} />
+                      <span className="weq-acct-row-avatar-wrap">
+                        <QqAvatar uin={acc.uin} url={acc.avatarUrl} size={38} />
+                        {acc.static && (
+                          <span className="weq-static-badge" title="静态离线账号" aria-label="静态离线账号">
+                            <Database size={9} strokeWidth={2.2} aria-hidden />
+                          </span>
+                        )}
+                      </span>
                       <div className="weq-acct-row-id">
                         <div className={acc.hasName ? 'weq-acct-row-name' : 'weq-acct-row-name weq-acct-name-strong'}>
                           {acc.name}

--- a/apps/desktop/src/renderer/src/views/bootstrap/HomeScreen.tsx
+++ b/apps/desktop/src/renderer/src/views/bootstrap/HomeScreen.tsx
@@ -1,22 +1,25 @@
 /**
- * Landing screen: brand logo + the two entry buttons.
+ * Landing screen: brand logo + the three entry buttons.
  *
  *   左 — 现有账号配置  (disabled when no saved config exists)
  *   右 — 新的开始
+ *   下方 — 本地已解密数据库读取（无需密钥，直接导入离线解密库）
  */
 
 import { type ReactElement } from 'react';
-import { FolderClock, Sparkles } from 'lucide-react';
+import { FolderClock, Sparkles, Database } from 'lucide-react';
 import logoUrl from '@resources/brand/logo.png';
 
 export function HomeScreen({
   hasConfigs,
   onExisting,
   onNew,
+  onStatic,
 }: {
   hasConfigs: boolean;
   onExisting: () => void;
   onNew: () => void;
+  onStatic: () => void;
 }): ReactElement {
   return (
     <div className="weq-home weq-anim-fade">
@@ -50,6 +53,16 @@ export function HomeScreen({
           <span className="weq-entry-text">
             <span className="weq-entry-title">新的开始</span>
             <span className="weq-entry-desc">检测账号并获取数据库密钥</span>
+          </span>
+        </button>
+
+        <button type="button" className="weq-entry-card is-static" onClick={onStatic}>
+          <span className="weq-entry-icon is-static">
+            <Database size={22} strokeWidth={1.7} aria-hidden />
+          </span>
+          <span className="weq-entry-text">
+            <span className="weq-entry-title">本地已解密数据库读取</span>
+            <span className="weq-entry-desc">导入已导出的离线解密数据库并查看（静态离线模式）</span>
           </span>
         </button>
       </div>

--- a/apps/desktop/src/renderer/src/views/bootstrap/HomeScreen.tsx
+++ b/apps/desktop/src/renderer/src/views/bootstrap/HomeScreen.tsx
@@ -1,25 +1,25 @@
 /**
- * Landing screen: brand logo + the three entry buttons.
+ * Landing screen: brand logo + the two entry buttons.
  *
  *   左 — 现有账号配置  (disabled when no saved config exists)
  *   右 — 新的开始
- *   下方 — 本地已解密数据库读取（无需密钥，直接导入离线解密库）
+ *
+ * The "本地备份导入" path lives INSIDE 「新的开始」 as a sub-tab — see
+ * `LoginPanel`. There's no top-level entry card for it.
  */
 
 import { type ReactElement } from 'react';
-import { FolderClock, Sparkles, Database } from 'lucide-react';
+import { FolderClock, Sparkles } from 'lucide-react';
 import logoUrl from '@resources/brand/logo.png';
 
 export function HomeScreen({
   hasConfigs,
   onExisting,
   onNew,
-  onStatic,
 }: {
   hasConfigs: boolean;
   onExisting: () => void;
   onNew: () => void;
-  onStatic: () => void;
 }): ReactElement {
   return (
     <div className="weq-home weq-anim-fade">
@@ -53,16 +53,6 @@ export function HomeScreen({
           <span className="weq-entry-text">
             <span className="weq-entry-title">新的开始</span>
             <span className="weq-entry-desc">检测账号并获取数据库密钥</span>
-          </span>
-        </button>
-
-        <button type="button" className="weq-entry-card is-static" onClick={onStatic}>
-          <span className="weq-entry-icon is-static">
-            <Database size={22} strokeWidth={1.7} aria-hidden />
-          </span>
-          <span className="weq-entry-text">
-            <span className="weq-entry-title">本地已解密数据库读取</span>
-            <span className="weq-entry-desc">导入已导出的离线解密数据库并查看（静态离线模式）</span>
           </span>
         </button>
       </div>

--- a/apps/desktop/src/renderer/src/views/bootstrap/LoginPanel.tsx
+++ b/apps/desktop/src/renderer/src/views/bootstrap/LoginPanel.tsx
@@ -11,13 +11,14 @@
  */
 
 import { useEffect, useRef, useState, type ReactElement } from 'react';
-import { Loader2, UserPlus } from 'lucide-react';
+import { ArrowRight, Loader2, UserPlus } from 'lucide-react';
 import { client } from '../../trpc/client';
 import { useDialog } from '../../components/Dialog';
 import type { AutoEnterTarget } from '@weq/service';
 import { AccountSelector } from './AccountSelector';
 import { KeyField, isCompleteKey } from './KeyField';
 import { QrDialog } from './QrDialog';
+import { StaticBackupPanel } from './StaticBackupPanel';
 import { deriveMsgDbPath, type UiAccount } from './types';
 
 type Sub = { unsubscribe: () => void };
@@ -56,6 +57,8 @@ export function LoginPanel({
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState('');
   const [autoEnter, setAutoEnter] = useState(false);
+  /** new mode only: which source to drive the wizard from. */
+  const [source, setSource] = useState<'online' | 'backup'>('online');
 
   // QR dialog state. `anonymous` = the "登录新的账号" flow, where the currently
   // selected account is irrelevant, so its identity must not be shown.
@@ -67,6 +70,7 @@ export function LoginPanel({
     setKey(mode === 'existing' ? (selected?.dbKey ?? '') : '');
     setStatus('');
     setAutoEnter(sameTarget(autoTarget, selected));
+    setSource('online');
   }, [selected?.key, mode, selected?.dbKey, autoTarget, selected]);
 
   // Tear down any live subscription on unmount.
@@ -203,6 +207,44 @@ export function LoginPanel({
 
   async function enter(): Promise<void> {
     if (!selected) return;
+
+    // Static (offline) accounts have no live key gate — re-open them directly
+    // from their saved decrypted-db directory + (optional) stored key.
+    if (selected.static) {
+      if (!selected.dataDir) {
+        showError('无法打开', '该静态账号缺少数据库目录，请重新导入。');
+        return;
+      }
+      setBusy(true);
+      setStatus('正在打开本地数据库…');
+      try {
+        await client.bootstrap.openStaticAccount.mutate({
+          dirPath: selected.dataDir,
+          preview: {
+            uin: selected.uin,
+            displayName: selected.hasName ? selected.name : '',
+            avatarUrl: selected.avatarUrl ?? '',
+          },
+          ...(selected.dbKey ? { dbKey: selected.dbKey } : {}),
+          ...(selected.algo?.pageHmacAlgorithm ? { algo: selected.algo } : {}),
+        });
+        if (autoEnter) {
+          await client.bootstrap.setAutoEnter.mutate({
+            uin: selected.uin,
+            ...(selected.dataDir ? { dataDir: selected.dataDir } : {}),
+          });
+        } else if (sameTarget(autoTarget, selected)) {
+          await client.bootstrap.clearAutoEnter.mutate();
+        }
+        onEntered(selected.uin);
+      } catch (e) {
+        setBusy(false);
+        setStatus('');
+        showError('进入失败', errMsg(e));
+      }
+      return;
+    }
+
     const k = key.trim();
     if (mode === 'new' && !isCompleteKey(k)) {
       showError('密钥不完整', '请先获取或填入 16 位数据库密钥。');
@@ -255,58 +297,103 @@ export function LoginPanel({
 
   return (
     <div className="weq-login-panel">
-      <AccountSelector
-        accounts={accounts}
-        selected={selected}
-        onSelect={onSelect}
-        footer={
-          mode === 'new' ? (
-            <button
-              type="button"
-              className="weq-acct-new"
-              onClick={() => selected && startQrLogin(selected, true)}
-            >
-              <UserPlus size={15} strokeWidth={1.8} aria-hidden />
-              登录新的账号
-            </button>
-          ) : undefined
-        }
-      />
-
-      {status && (
-        <div className="weq-login-status">
-          {busy && <Loader2 className="animate-spin" size={13} strokeWidth={1.85} aria-hidden />}
-          {status}
-        </div>
+      {mode === 'new' && (
+        <nav className="weq-source-tabs" role="tablist" aria-label="账号来源">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={source === 'online'}
+            className={`weq-source-tab ${source === 'online' ? 'is-active' : ''}`}
+            onClick={() => setSource('online')}
+          >
+            在线账号
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={source === 'backup'}
+            className={`weq-source-tab ${source === 'backup' ? 'is-active' : ''}`}
+            onClick={() => setSource('backup')}
+          >
+            本地备份
+          </button>
+        </nav>
       )}
 
-      <KeyField
-        mode={mode}
-        value={key}
-        onChange={setKey}
-        onAction={onAction}
-        busy={busy}
-      />
+      {mode === 'new' && source === 'backup' ? (
+        <StaticBackupPanel onEntered={onEntered} />
+      ) : (
+        <>
+          <AccountSelector
+            accounts={accounts}
+            selected={selected}
+            onSelect={onSelect}
+            footer={
+              mode === 'new' ? (
+                <button
+                  type="button"
+                  className="weq-acct-new"
+                  onClick={() => selected && startQrLogin(selected, true)}
+                >
+                  <UserPlus size={15} strokeWidth={1.8} aria-hidden />
+                  登录新的账号
+                </button>
+              ) : undefined
+            }
+          />
 
-      <label className="weq-auto-enter">
-        <input
-          type="checkbox"
-          checked={autoEnter}
-          onChange={(e) => setAutoEnter(e.target.checked)}
-        />
-        <span>下次打开自动进入该账号</span>
-      </label>
+          {status && (
+            <div className="weq-login-status">
+              {busy && <Loader2 className="animate-spin" size={13} strokeWidth={1.85} aria-hidden />}
+              {status}
+            </div>
+          )}
 
-      {qr && (
-        <QrDialog
-          uin={qr.uin}
-          name={qr.name}
-          avatarUrl={qr.avatarUrl}
-          status={qr.status}
-          qrUrl={qr.url}
-          anonymous={qr.anonymous}
-          onClose={cancelQr}
-        />
+          {selected?.static ? (
+            <button
+              type="button"
+              className="weq-action-primary weq-static-enter"
+              onClick={() => void enter()}
+              disabled={busy}
+            >
+              {busy ? (
+                <Loader2 className="animate-spin" size={15} strokeWidth={1.8} aria-hidden />
+              ) : (
+                <ArrowRight size={15} strokeWidth={1.85} aria-hidden />
+              )}
+              进入（静态离线账号）
+            </button>
+          ) : (
+            <KeyField
+              mode={mode}
+              value={key}
+              onChange={setKey}
+              onAction={onAction}
+              busy={busy}
+            />
+          )}
+
+          <label className="weq-auto-enter">
+            <input
+              type="checkbox"
+              checked={autoEnter}
+              onChange={(e) => setAutoEnter(e.target.checked)}
+            />
+            <span>下次打开自动进入该账号</span>
+          </label>
+
+          {qr && (
+            <QrDialog
+              uin={qr.uin}
+              name={qr.name}
+              avatarUrl={qr.avatarUrl}
+              status={qr.status}
+              qrUrl={qr.url}
+              anonymous={qr.anonymous}
+              onClose={cancelQr}
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/apps/desktop/src/renderer/src/views/bootstrap/SelectScreen.tsx
+++ b/apps/desktop/src/renderer/src/views/bootstrap/SelectScreen.tsx
@@ -60,6 +60,7 @@ export function SelectScreen({ install }: { install: GlobalInstallInfo }): React
         algo: cfg.algo,
         ...(cfg.dataDir ? { dataDir: cfg.dataDir } : root ? { dataDir: `${root}\\${cfg.uin}` } : {}),
         lastLoginAt: cfg.lastLoginAt,
+        ...(cfg.static ? { static: true } : {}),
       }));
     }
     return (historical.data ?? []).map((a) => ({

--- a/apps/desktop/src/renderer/src/views/bootstrap/StaticBackupPanel.tsx
+++ b/apps/desktop/src/renderer/src/views/bootstrap/StaticBackupPanel.tsx
@@ -1,0 +1,216 @@
+/**
+ * Static backup import panel — shown inside 「新的开始」 under the "本地备份" tab.
+ *
+ * Flow:
+ *   1. User picks a directory (the standard OS folder dialog).
+ *   2. 「测试打开」 probes profile_info_v6 with no key. If the db is plain
+ *      SQLite we resolve the self row (UIN + nick + avatar) and show the
+ *      confirmation card.
+ *   3. If the probe reports `needKey`, a key field appears inline (the
+ *      failure UX — no modal). User enters the SQLCipher key and re-tests.
+ *   4. On success, 「进入」 opens the account via `openStaticAccount`. We do
+ *      NOT persist auto-enter here — static accounts already save themselves
+ *      into the accounts/ directory on the backend.
+ */
+
+import { useState, type ReactElement } from 'react';
+import { ArrowRight, Database, FolderSearch, HelpCircle, KeyRound, Loader2 } from 'lucide-react';
+import { client } from '../../trpc/client';
+import { useDialog } from '../../components/Dialog';
+import { QqAvatar } from '../../components/QqAvatar';
+import { isCompleteKey } from './KeyField';
+import qqLogoUrl from '@resources/img/QQ.png';
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+type Probe =
+  | { kind: 'idle' }
+  | { kind: 'probing' }
+  | { kind: 'ready'; preview: { uin: string; displayName: string; avatarUrl: string } }
+  | { kind: 'needKey' }
+  | { kind: 'badKey' }
+  | { kind: 'badDb'; error: string };
+
+type Stage = 'picking' | 'probing' | 'done';
+
+export function StaticBackupPanel({ onEntered }: { onEntered: (uin: string) => void }): ReactElement {
+  const showError = useDialog((s) => s.showError);
+
+  const [dirPath, setDirPath] = useState<string>('');
+  const [key, setKey] = useState<string>('');
+  const [stage, setStage] = useState<Stage>('picking');
+  const [probe, setProbe] = useState<Probe>({ kind: 'idle' });
+
+  async function pickDir(): Promise<void> {
+    const picked = await client.bootstrap.pickStaticDbDir.mutate();
+    if (!picked) return;
+    setDirPath(picked);
+    setKey('');
+    setProbe({ kind: 'idle' });
+    setStage('picking');
+  }
+
+  async function testOpen(): Promise<void> {
+    if (!dirPath) return;
+    setStage('probing');
+    setProbe({ kind: 'probing' });
+    try {
+      const r = await client.bootstrap.testStaticDir.mutate({
+        dirPath,
+        ...(isCompleteKey(key) ? { dbKey: key } : {}),
+      });
+      if (!r.ok) {
+        setProbe({ kind: 'badDb', error: r.error });
+        setStage('picking');
+        return;
+      }
+      if (r.needKey) {
+        setProbe({ kind: 'needKey' });
+        setStage('picking');
+        return;
+      }
+      setProbe({ kind: 'ready', preview: r.preview });
+      setStage('done');
+    } catch (e) {
+      setProbe({ kind: 'badDb', error: errMsg(e) });
+      setStage('picking');
+    }
+  }
+
+  async function enter(): Promise<void> {
+    if (probe.kind !== 'ready') return;
+    try {
+      await client.bootstrap.openStaticAccount.mutate({
+        dirPath,
+        preview: probe.preview,
+        ...(isCompleteKey(key) ? { dbKey: key } : {}),
+      });
+      onEntered(probe.preview.uin);
+    } catch (e) {
+      showError('打开失败', errMsg(e));
+    }
+  }
+
+  return (
+    <div className="weq-static-backup">
+      <div className="weq-static-backup-head">
+        {probe.kind === 'ready' ? (
+          <>
+            <span className="weq-static-backup-avatar-wrap">
+              <QqAvatar
+                uin={probe.preview.uin}
+                url={probe.preview.avatarUrl || null}
+                size={140}
+                className="weq-acct-avatar"
+              />
+              <span className="weq-static-badge is-lg" title="静态离线账号" aria-label="静态离线账号">
+                <Database size={13} strokeWidth={2.2} aria-hidden />
+              </span>
+            </span>
+            <div className="weq-static-backup-title">
+              {probe.preview.displayName || probe.preview.uin}
+            </div>
+          </>
+        ) : (
+          <>
+            <img src={qqLogoUrl} alt="" width={140} height={140} className="weq-static-backup-logo" aria-hidden />
+            <div className="weq-static-backup-title">导入本地数据库</div>
+          </>
+        )}
+      </div>
+
+      <div className="weq-static-help">
+        <HelpCircle size={15} strokeWidth={1.8} aria-hidden />
+        <span>
+          导入非 QQ 本体的实际目录（来自手机备份，或其他工具解密的文件夹）。
+          数据库需全部平铺在该目录中；无法查看和下载媒体。
+        </span>
+      </div>
+
+      <label className="weq-static-row">
+        <span className="weq-static-label">
+          <FolderSearch size={15} strokeWidth={1.8} aria-hidden />
+          数据库目录
+        </span>
+        <span className="weq-static-inputwrap">
+          <input
+            className="weq-static-input"
+            value={dirPath}
+            readOnly
+            placeholder="请选择包含 nt_msg.db / profile_info.db 的目录"
+          />
+          <button type="button" className="weq-action-primary" onClick={() => void pickDir()}>
+            浏览…
+          </button>
+        </span>
+      </label>
+
+      {(probe.kind === 'needKey' || probe.kind === 'badKey') && (
+        <label className="weq-static-row">
+          <span className="weq-static-label">
+            <KeyRound size={15} strokeWidth={1.8} aria-hidden />
+            数据库密钥
+          </span>
+          <span className="weq-static-inputwrap">
+            <input
+              className={`weq-static-input ${probe.kind === 'badKey' ? 'is-error' : ''}`}
+              value={key}
+              spellCheck={false}
+              autoComplete="off"
+              placeholder="16 位 SQLCipher 密钥（不输则按 SQLite 直接打开）"
+              onChange={(e) => {
+                setKey(e.target.value.trim());
+                if (probe.kind === 'badKey') setProbe({ kind: 'needKey' });
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void testOpen();
+              }}
+            />
+            <button
+              type="button"
+              className="weq-action-primary"
+              onClick={() => void testOpen()}
+              disabled={!dirPath}
+            >
+              重新测试
+            </button>
+          </span>
+          <span className="weq-static-hint">
+            {probe.kind === 'badKey'
+              ? '密钥不正确或数据库格式不符，请检查后重试。'
+              : '检测到加密数据库，请输入 16 位密钥后重新测试。'}
+          </span>
+        </label>
+      )}
+
+      <div className="weq-static-actions">
+        {probe.kind !== 'ready' ? (
+          <button
+            type="button"
+            className="weq-action-primary"
+            onClick={() => void testOpen()}
+            disabled={!dirPath || stage === 'probing'}
+          >
+            {stage === 'probing' ? (
+              <Loader2 className="animate-spin" size={15} strokeWidth={1.8} aria-hidden />
+            ) : (
+              <Database size={15} strokeWidth={1.8} aria-hidden />
+            )}
+            测试打开
+          </button>
+        ) : (
+          <button type="button" className="weq-action-primary" onClick={() => void enter()}>
+            <ArrowRight size={15} strokeWidth={1.85} aria-hidden />
+            进入
+          </button>
+        )}
+      </div>
+
+      {probe.kind === 'badDb' && (
+        <div className="weq-static-error">打开失败：{probe.error}</div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/views/bootstrap/types.ts
+++ b/apps/desktop/src/renderer/src/views/bootstrap/types.ts
@@ -24,6 +24,8 @@ export interface UiAccount {
   algo?: DatabaseAlgorithms;
   dataDir?: string;
   lastLoginAt?: number;
+  /** True for static / offline (decrypted-db directory) accounts. */
+  static?: boolean;
 
   // ---- new-start mode ----
   /** Non-empty marker ⇒ account is quick-login-able. */

--- a/packages/account/src/index.ts
+++ b/packages/account/src/index.ts
@@ -7,3 +7,4 @@
 
 export { openAccount } from './session';
 export type { AccountContext, AccountSession, LastRowIdMaps } from './session';
+export { openStaticAccount } from './static_session';

--- a/packages/account/src/index.ts
+++ b/packages/account/src/index.ts
@@ -7,4 +7,5 @@
 
 export { openAccount } from './session';
 export type { AccountContext, AccountSession, LastRowIdMaps } from './session';
-export { openStaticAccount } from './static_session';
+export { openStaticAccount, peekStaticSelfUin } from './static_session';
+export type { OpenStaticAccountOptions, StaticSelfPreview } from './static_session';

--- a/packages/account/src/static_session.ts
+++ b/packages/account/src/static_session.ts
@@ -1,15 +1,20 @@
 /**
- * Static (offline) account session — opens an already-decrypted local QQ
- * database directory without needing a dbKey or live QQ process.
+ * Static (offline) account session — opens a directory of locally-stored
+ * QQ databases. Two flavors:
  *
- * The directory is expected to contain plain SQLite `.db` files (the result
- * of a prior bulk-decrypt). The directory name is treated as the account UIN.
+ *   1. Already-decrypted plain SQLite (no key required)
+ *   2. Still-encrypted SQLCipher databases (key + algorithm required)
+ *
+ * The UIN is NOT derived from the directory name — it is read from
+ * `profile_info.db → profile_info_v6`'s first row, column `"1002"`. This
+ * works for phone backups or third-party decrypted folders whose directory
+ * names carry no reliable UIN.
  *
  * Same lifecycle as the online session: caller must `dispose()` before
  * opening another account to drop the cached native connections.
  */
 
-import { basename, join } from 'node:path';
+import { join } from 'node:path';
 import { existsSync } from 'node:fs';
 import {
   C2cMsgDb,
@@ -32,8 +37,10 @@ import {
   BuddyRequestDb,
   ProfileInfoDb,
   MiscDb,
+  QqDb,
   UnreadInfoDb,
 } from '@weq/db';
+import type { DatabaseAlgorithms } from '@weq/native';
 import type { Platform } from '@weq/platform';
 import type { AccountSession } from './session';
 
@@ -45,26 +52,100 @@ function requireFile(dirPath: string, filename: string): string {
   return p;
 }
 
-export async function openStaticAccount(
+function dbOpts(profileInfoPath: string, dbKey?: string, algo?: DatabaseAlgorithms) {
+  return { dbPath: profileInfoPath, ...(dbKey ? { key: dbKey } : {}), ...(algo ? { algo } : {}) };
+}
+
+/**
+ * Read the self row from `profile_info_v6` (the first row is the account
+ * owner). Throws on missing files / SQLCipher-without-key / bad schema so
+ * the caller can show a friendly "needs key" prompt.
+ */
+export interface StaticSelfPreview {
+  uin: string;
+  nick: string;
+  avatarUrl: string;
+  uid: string;
+}
+
+export async function peekStaticSelfUin(
   platform: Platform,
   dirPath: string,
-): Promise<AccountSession> {
+  dbKey?: string,
+  algo?: DatabaseAlgorithms,
+): Promise<StaticSelfPreview> {
   const nt = platform.native.ntHelper;
-  const uin = basename(dirPath);
-
-  if (!uin || uin.length < 5) {
-    throw new Error(`Cannot derive a valid UIN from directory name: ${dirPath}`);
+  const profileInfoPath = requireFile(dirPath, 'profile_info.db');
+  // Probe via QqDb directly (not ProfileInfoDb) so we don't drag every
+  // profile column through the codec pipeline just to read 4 fields.
+  const qq = new QqDb(nt, dbOpts(profileInfoPath, dbKey, algo));
+  try {
+    // 1002 = uin, 20002 = nick, 20004 = avatarUrl, 1000 = uid
+    // First row of profile_info_v6 is always the account owner.
+    const rows = await qq.query(
+      `SELECT "1000","1002","20002","20004" FROM profile_info_v6 LIMIT 1`,
+    );
+    if (rows.length === 0 || rows[0] === undefined) {
+      throw new Error('profile_info_v6 为空，无法识别账号');
+    }
+    const row = rows[0];
+    const uinRaw = row[1];
+    const uin = uinRaw === null || uinRaw === undefined ? '' : String(uinRaw);
+    if (!uin) throw new Error('profile_info_v6 中未找到有效的 UIN');
+    return {
+      uin,
+      uid: String(row[0] ?? ''),
+      nick: String(row[2] ?? ''),
+      avatarUrl: String(row[3] ?? ''),
+    };
+  } finally {
+    qq.close();
   }
+}
+
+export interface OpenStaticAccountOptions {
+  /** Path to the directory containing the QQ .db files. */
+  dirPath: string;
+  /**
+   * SQLCipher key. Omit / leave blank for plain (already-decrypted) SQLite.
+   * The native helper auto-probes the matching algorithms when `algo` is
+   * omitted, so callers don't need to know the exact cipher params.
+   */
+  dbKey?: string;
+  /**
+   * Resolved SQLCipher algorithms. Optional — when omitted AND `dbKey` is
+   * provided, the native helper is asked to probe them.
+   */
+  algo?: DatabaseAlgorithms;
+  /**
+   * Pre-resolved self preview. Required — the directory name is not used as
+   * a UIN fallback. Run {@link peekStaticSelfUin} first to obtain it.
+   */
+  self: StaticSelfPreview;
+}
+
+/**
+ * Open a static (offline) account. Caller MUST supply `self` from
+ * {@link peekStaticSelfUin} so we don't trust the directory name.
+ */
+export async function openStaticAccount(
+  platform: Platform,
+  options: OpenStaticAccountOptions,
+): Promise<AccountSession> {
+  const { dirPath, dbKey, algo, self } = options;
+  const nt = platform.native.ntHelper;
+  const uin = self.uin;
+  const opts = (dbPath: string) => dbOpts(dbPath, dbKey, algo);
 
   // ---- core databases ----
   const msgDbPath = requireFile(dirPath, 'nt_msg.db');
 
-  const c2cMsgs = new C2cMsgDb(nt, { dbPath: msgDbPath });
-  const groupMsgs = new GroupMsgDb(nt, { dbPath: msgDbPath });
-  const recentContacts = new RecentContactDb(nt, { dbPath: msgDbPath });
+  const c2cMsgs = new C2cMsgDb(nt, opts(msgDbPath));
+  const groupMsgs = new GroupMsgDb(nt, opts(msgDbPath));
+  const recentContacts = new RecentContactDb(nt, opts(msgDbPath));
 
   // Load the uid ↔ uin ↔ sortNo directory.
-  const uidMappingDb = new UidMappingDb(nt, { dbPath: msgDbPath });
+  const uidMappingDb = new UidMappingDb(nt, opts(msgDbPath));
   let uidMap: UidMap;
   try {
     uidMap = UidMap.from(await uidMappingDb.listAll());
@@ -75,41 +156,43 @@ export async function openStaticAccount(
     uidMappingDb.close();
   }
 
-  const forwardMsgs = new ForwardMsgDb(nt, { dbPath: msgDbPath });
-  const unreadInfo = new UnreadInfoDb(nt, { dbPath: msgDbPath });
+  const forwardMsgs = new ForwardMsgDb(nt, opts(msgDbPath));
+  const unreadInfo = new UnreadInfoDb(nt, opts(msgDbPath));
 
   // ---- full-text-search indexes (may not exist; search will fail gracefully) ----
-  const buddyMsgFts = new BuddyMsgFtsDb(nt, { dbPath: join(dirPath, 'buddy_msg_fts.db') });
-  const groupMsgFts = new GroupMsgFtsDb(nt, { dbPath: join(dirPath, 'group_msg_fts.db') });
+  const buddyMsgFts = new BuddyMsgFtsDb(nt, opts(join(dirPath, 'buddy_msg_fts.db')));
+  const groupMsgFts = new GroupMsgFtsDb(nt, opts(join(dirPath, 'group_msg_fts.db')));
 
   // ---- group info ----
   const groupInfoDbPath = requireFile(dirPath, 'group_info.db');
-  const groupEssence = new GroupEssenceDb(nt, { dbPath: groupInfoDbPath });
-  const memberLevelInfo = new GroupMemberLevelInfoDb(nt, { dbPath: groupInfoDbPath });
-  const groupDetail = new GroupDetailDb(nt, { dbPath: groupInfoDbPath });
-  const groupBulletins = new GroupBulletinDb(nt, { dbPath: groupInfoDbPath });
-  const groupMembers = new GroupMemberDb(nt, { dbPath: groupInfoDbPath });
-  const groupNotifies = new GroupNotifyDb(nt, { dbPath: groupInfoDbPath });
+  const groupInfoOpts = opts(groupInfoDbPath);
+  const groupEssence = new GroupEssenceDb(nt, groupInfoOpts);
+  const memberLevelInfo = new GroupMemberLevelInfoDb(nt, groupInfoOpts);
+  const groupDetail = new GroupDetailDb(nt, groupInfoOpts);
+  const groupBulletins = new GroupBulletinDb(nt, groupInfoOpts);
+  const groupMembers = new GroupMemberDb(nt, groupInfoOpts);
+  const groupNotifies = new GroupNotifyDb(nt, groupInfoOpts);
 
   // ---- file assistant (may not exist) ----
-  const fileAssistant = new FileAssistantDb(nt, { dbPath: join(dirPath, 'file_assistant.db') });
+  const fileAssistant = new FileAssistantDb(nt, opts(join(dirPath, 'file_assistant.db')));
 
   // ---- profile ----
   const profileInfoPath = requireFile(dirPath, 'profile_info.db');
-  const buddies = new BuddyDb(nt, { dbPath: profileInfoPath });
-  const categories = new CategoryDb(nt, { dbPath: profileInfoPath });
-  const buddyReqs = new BuddyRequestDb(nt, { dbPath: profileInfoPath });
-  const profileInfo = new ProfileInfoDb(nt, { dbPath: profileInfoPath });
+  const profileOpts = opts(profileInfoPath);
+  const buddies = new BuddyDb(nt, profileOpts);
+  const categories = new CategoryDb(nt, profileOpts);
+  const buddyReqs = new BuddyRequestDb(nt, profileOpts);
+  const profileInfo = new ProfileInfoDb(nt, profileOpts);
 
   // ---- misc ----
-  const misc = new MiscDb(nt, { dbPath: join(dirPath, 'misc.db') });
+  const misc = new MiscDb(nt, opts(join(dirPath, 'misc.db')));
 
   let disposed = false;
   return {
     context: {
       uin,
-      dbKey: '',
-      algo: { pageHmacAlgorithm: '', kdfHmacAlgorithm: '' },
+      dbKey: dbKey ?? '',
+      algo: algo ?? { pageHmacAlgorithm: '', kdfHmacAlgorithm: '' },
     },
     msgDbPath,
     lastRowIdMaps: { c2cRowId: 0n, groupRowId: 0n, guildRowId: 0n },

--- a/packages/account/src/static_session.ts
+++ b/packages/account/src/static_session.ts
@@ -1,0 +1,160 @@
+/**
+ * Static (offline) account session — opens an already-decrypted local QQ
+ * database directory without needing a dbKey or live QQ process.
+ *
+ * The directory is expected to contain plain SQLite `.db` files (the result
+ * of a prior bulk-decrypt). The directory name is treated as the account UIN.
+ *
+ * Same lifecycle as the online session: caller must `dispose()` before
+ * opening another account to drop the cached native connections.
+ */
+
+import { basename, join } from 'node:path';
+import { existsSync } from 'node:fs';
+import {
+  C2cMsgDb,
+  GroupMsgDb,
+  RecentContactDb,
+  UidMappingDb,
+  UidMap,
+  ForwardMsgDb,
+  BuddyMsgFtsDb,
+  GroupMsgFtsDb,
+  GroupEssenceDb,
+  GroupMemberLevelInfoDb,
+  GroupDetailDb,
+  GroupBulletinDb,
+  GroupMemberDb,
+  GroupNotifyDb,
+  FileAssistantDb,
+  BuddyDb,
+  CategoryDb,
+  BuddyRequestDb,
+  ProfileInfoDb,
+  MiscDb,
+  UnreadInfoDb,
+} from '@weq/db';
+import type { Platform } from '@weq/platform';
+import type { AccountSession } from './session';
+
+function requireFile(dirPath: string, filename: string): string {
+  const p = join(dirPath, filename);
+  if (!existsSync(p)) {
+    throw new Error(`${filename} not found in selected directory: ${dirPath}`);
+  }
+  return p;
+}
+
+export async function openStaticAccount(
+  platform: Platform,
+  dirPath: string,
+): Promise<AccountSession> {
+  const nt = platform.native.ntHelper;
+  const uin = basename(dirPath);
+
+  if (!uin || uin.length < 5) {
+    throw new Error(`Cannot derive a valid UIN from directory name: ${dirPath}`);
+  }
+
+  // ---- core databases ----
+  const msgDbPath = requireFile(dirPath, 'nt_msg.db');
+
+  const c2cMsgs = new C2cMsgDb(nt, { dbPath: msgDbPath });
+  const groupMsgs = new GroupMsgDb(nt, { dbPath: msgDbPath });
+  const recentContacts = new RecentContactDb(nt, { dbPath: msgDbPath });
+
+  // Load the uid ↔ uin ↔ sortNo directory.
+  const uidMappingDb = new UidMappingDb(nt, { dbPath: msgDbPath });
+  let uidMap: UidMap;
+  try {
+    uidMap = UidMap.from(await uidMappingDb.listAll());
+  } catch (e) {
+    console.error('[static-account] failed to load nt_uid_mapping_table — using empty uid map:', e);
+    uidMap = UidMap.from([]);
+  } finally {
+    uidMappingDb.close();
+  }
+
+  const forwardMsgs = new ForwardMsgDb(nt, { dbPath: msgDbPath });
+  const unreadInfo = new UnreadInfoDb(nt, { dbPath: msgDbPath });
+
+  // ---- full-text-search indexes (may not exist; search will fail gracefully) ----
+  const buddyMsgFts = new BuddyMsgFtsDb(nt, { dbPath: join(dirPath, 'buddy_msg_fts.db') });
+  const groupMsgFts = new GroupMsgFtsDb(nt, { dbPath: join(dirPath, 'group_msg_fts.db') });
+
+  // ---- group info ----
+  const groupInfoDbPath = requireFile(dirPath, 'group_info.db');
+  const groupEssence = new GroupEssenceDb(nt, { dbPath: groupInfoDbPath });
+  const memberLevelInfo = new GroupMemberLevelInfoDb(nt, { dbPath: groupInfoDbPath });
+  const groupDetail = new GroupDetailDb(nt, { dbPath: groupInfoDbPath });
+  const groupBulletins = new GroupBulletinDb(nt, { dbPath: groupInfoDbPath });
+  const groupMembers = new GroupMemberDb(nt, { dbPath: groupInfoDbPath });
+  const groupNotifies = new GroupNotifyDb(nt, { dbPath: groupInfoDbPath });
+
+  // ---- file assistant (may not exist) ----
+  const fileAssistant = new FileAssistantDb(nt, { dbPath: join(dirPath, 'file_assistant.db') });
+
+  // ---- profile ----
+  const profileInfoPath = requireFile(dirPath, 'profile_info.db');
+  const buddies = new BuddyDb(nt, { dbPath: profileInfoPath });
+  const categories = new CategoryDb(nt, { dbPath: profileInfoPath });
+  const buddyReqs = new BuddyRequestDb(nt, { dbPath: profileInfoPath });
+  const profileInfo = new ProfileInfoDb(nt, { dbPath: profileInfoPath });
+
+  // ---- misc ----
+  const misc = new MiscDb(nt, { dbPath: join(dirPath, 'misc.db') });
+
+  let disposed = false;
+  return {
+    context: {
+      uin,
+      dbKey: '',
+      algo: { pageHmacAlgorithm: '', kdfHmacAlgorithm: '' },
+    },
+    msgDbPath,
+    lastRowIdMaps: { c2cRowId: 0n, groupRowId: 0n, guildRowId: 0n },
+    uidMap,
+    c2cMsgs,
+    groupMsgs,
+    recentContacts,
+    forwardMsgs,
+    buddyMsgFts,
+    groupMsgFts,
+    groupEssence,
+    memberLevelInfo,
+    groupDetail,
+    groupBulletins,
+    groupMembers,
+    groupNotifies,
+    fileAssistant,
+    buddies,
+    categories,
+    buddyReqs,
+    profileInfo,
+    misc,
+    unreadInfo,
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      c2cMsgs.close();
+      groupMsgs.close();
+      recentContacts.close();
+      forwardMsgs.close();
+      buddyMsgFts.close();
+      groupMsgFts.close();
+      groupEssence.close();
+      memberLevelInfo.close();
+      groupDetail.close();
+      groupBulletins.close();
+      groupMembers.close();
+      groupNotifies.close();
+      fileAssistant.close();
+      buddies.close();
+      categories.close();
+      buddyReqs.close();
+      profileInfo.close();
+      misc.close();
+      unreadInfo.close();
+    },
+  };
+}

--- a/packages/db/src/contact/recent_contact.ts
+++ b/packages/db/src/contact/recent_contact.ts
@@ -40,10 +40,10 @@ const BLOCKED_CHAT_TYPES: readonly number[] = [ChatType.KCHATTYPEGUILDMETA];
 export interface RecentContactDbOptions {
   /** Absolute path to nt_msg.db. */
   dbPath: string;
-  /** SQLCipher key. */
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  /** SQLCipher key. (omit for plain decrypted). */
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 export class RecentContactDb {

--- a/packages/db/src/contact/uid_mapping.ts
+++ b/packages/db/src/contact/uid_mapping.ts
@@ -36,10 +36,10 @@ export interface UidMappingRow {
 export interface UidMappingDbOptions {
   /** Absolute path to nt_msg.db. */
   dbPath: string;
-  /** SQLCipher key. */
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  /** SQLCipher key. (omit for plain decrypted). */
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 export class UidMappingDb {

--- a/packages/db/src/file_assistant/file_assistant.ts
+++ b/packages/db/src/file_assistant/file_assistant.ts
@@ -15,8 +15,8 @@ export interface FileAssistantRow {
 
 export interface FileAssistantDbOptions {
   dbPath: string;
-  key: string;
-  algo: DatabaseAlgorithms;
+  key?: string;
+  algo?: DatabaseAlgorithms;
 }
 
 const SELECT_COLUMNS = `"200002", "200001", "200016", "200005", "200009", "1000", "40021", "200011"`;

--- a/packages/db/src/group_info/bulletin.ts
+++ b/packages/db/src/group_info/bulletin.ts
@@ -24,9 +24,9 @@ export interface GroupBulletin {
 
 export interface GroupBulletinDbOptions {
   dbPath: string;
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 const SELECT_COLUMNS = `"60001","64205"`;

--- a/packages/db/src/group_info/detail.ts
+++ b/packages/db/src/group_info/detail.ts
@@ -64,9 +64,9 @@ export interface GroupDetail {
 
 export interface GroupDetailDbOptions {
   dbPath: string;
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 const SELECT_COLUMNS = `"60001","60007","60216","60217","60026","60002","60004","60005","60006","60218","60224","60340","60241","60242"`;

--- a/packages/db/src/group_info/essence.ts
+++ b/packages/db/src/group_info/essence.ts
@@ -31,9 +31,9 @@ export interface GroupEssence {
 
 export interface GroupEssenceDbOptions {
   dbPath: string;
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 const SELECT_COLUMNS = `"60001","67501","67502","67503","67504","67505","67506","67507","67508"`;

--- a/packages/db/src/group_info/member.ts
+++ b/packages/db/src/group_info/member.ts
@@ -37,9 +37,9 @@ export interface GroupMember {
 
 export interface GroupMemberDbOptions {
   dbPath: string;
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 const SELECT_COLUMNS = `"60001","1000","1002","64003","20002","64007","64008","64009","64010","64016","64023","64035"`;

--- a/packages/db/src/group_info/member_level.ts
+++ b/packages/db/src/group_info/member_level.ts
@@ -27,9 +27,9 @@ export interface GroupMemberLevelInfo {
 
 export interface GroupMemberLevelInfoDbOptions {
   dbPath: string;
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 const SELECT_COLUMNS = `"60001","67100","67103"`;

--- a/packages/db/src/group_info/notify.ts
+++ b/packages/db/src/group_info/notify.ts
@@ -55,8 +55,8 @@ export interface GroupNotify {
 
 export interface GroupNotifyDbOptions {
   dbPath: string;
-  key: string;
-  algo: DatabaseAlgorithms;
+  key?: string;
+  algo?: DatabaseAlgorithms;
 }
 
 const SELECT_COLUMNS = `"61001","61002","61003","61004","61005","61006","61007","61008","61010","61011"`;

--- a/packages/db/src/msg/buddy_msg_fts.ts
+++ b/packages/db/src/msg/buddy_msg_fts.ts
@@ -41,10 +41,10 @@ const MAX_POOL = 500;
 export interface BuddyMsgFtsDbOptions {
   /** Absolute path to buddy_msg_fts.db. */
   dbPath: string;
-  /** SQLCipher key. */
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  /** SQLCipher key. (omit for plain decrypted). */
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 export class BuddyMsgFtsDb {

--- a/packages/db/src/msg/c2c.ts
+++ b/packages/db/src/msg/c2c.ts
@@ -43,10 +43,10 @@ function partitionWhere(part: C2cPartition): { clause: string; value: SqlValue }
 export interface C2cMsgDbOptions {
   /** Absolute path to nt_msg.db. */
   dbPath: string;
-  /** SQLCipher key. */
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  /** SQLCipher key. (omit for plain decrypted). */
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 export class C2cMsgDb {

--- a/packages/db/src/msg/forward.ts
+++ b/packages/db/src/msg/forward.ts
@@ -17,10 +17,10 @@ import { QqDb } from '../qq_db';
 export interface ForwardMsgDbOptions {
   /** Absolute path to nt_msg.db. */
   dbPath: string;
-  /** SQLCipher key. */
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  /** SQLCipher key. (omit for plain decrypted). */
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 export class ForwardMsgDb {

--- a/packages/db/src/msg/group.ts
+++ b/packages/db/src/msg/group.ts
@@ -27,10 +27,10 @@ const SELECT_COLUMNS = `"40001","40020","40027","40033","40050","40800","40062",
 export interface GroupMsgDbOptions {
   /** Absolute path to nt_msg.db. */
   dbPath: string;
-  /** SQLCipher key. */
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  /** SQLCipher key. (omit for plain decrypted). */
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 export class GroupMsgDb {

--- a/packages/db/src/msg/group_msg_fts.ts
+++ b/packages/db/src/msg/group_msg_fts.ts
@@ -16,10 +16,10 @@ const MAX_POOL = 500;
 export interface GroupMsgFtsDbOptions {
   /** Absolute path to group_msg_fts.db. */
   dbPath: string;
-  /** SQLCipher key. */
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  /** SQLCipher key. (omit for plain decrypted). */
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 export class GroupMsgFtsDb {

--- a/packages/db/src/msg/unread_info.ts
+++ b/packages/db/src/msg/unread_info.ts
@@ -13,8 +13,8 @@ import { UnreadInfo } from '@weq/codec/proto/msg/48902';
 
 export interface UnreadInfoDbOptions {
   dbPath: string;
-  key: string;
-  algo: DatabaseAlgorithms;
+  key?: string;
+  algo?: DatabaseAlgorithms;
 }
 
 export interface UnreadInfoResult {

--- a/packages/db/src/profile/buddy.ts
+++ b/packages/db/src/profile/buddy.ts
@@ -20,8 +20,8 @@ export interface Buddy {
 
 export interface BuddyDbOptions {
   dbPath: string;
-  key: string;
-  algo: DatabaseAlgorithms;
+  key?: string;
+  algo?: DatabaseAlgorithms;
 }
 
 const SELECT_COLUMNS = `"1000","1001","1002","25007"`;

--- a/packages/db/src/profile/buddy_req.ts
+++ b/packages/db/src/profile/buddy_req.ts
@@ -30,8 +30,8 @@ export interface BuddyRequest {
 
 export interface BuddyRequestDbOptions {
   dbPath: string;
-  key: string;
-  algo: DatabaseAlgorithms;
+  key?: string;
+  algo?: DatabaseAlgorithms;
 }
 
 const SELECT_COLUMNS = `"21204","21001","20002","21502","21508","21509","21505","60001","21501"`;

--- a/packages/db/src/profile/category.ts
+++ b/packages/db/src/profile/category.ts
@@ -19,9 +19,9 @@ export interface Category {
 
 export interface CategoryDbOptions {
   dbPath: string;
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 export class CategoryDb {

--- a/packages/db/src/profile/profile_info.ts
+++ b/packages/db/src/profile/profile_info.ts
@@ -61,9 +61,9 @@ export interface UserProfile {
 
 export interface ProfileInfoDbOptions {
   dbPath: string;
-  key: string;
-  /** Database algorithms. */
-  algo: DatabaseAlgorithms;
+  key?: string;
+  /** Database algorithms (omit for plain decrypted). */
+  algo?: DatabaseAlgorithms;
 }
 
 const SELECT_COLUMNS = `"1000","1001","1002","20002","20004","20006","20007","20008","20009","20011","20014","20057","20070","20072","24103","24104"`;

--- a/packages/db/src/qq_db.ts
+++ b/packages/db/src/qq_db.ts
@@ -21,23 +21,31 @@ import type {
 export interface QqDbOptions {
   /** Absolute path to the QQ NT database file (encrypted, with QQ wrapper). */
   dbPath: string;
-  /** SQLCipher key (hex passphrase or raw ASCII — both work). */
-  key: string;
-  /** Cryptographic algorithms used for this database. */
-  algo: DatabaseAlgorithms;
+  /**
+   * SQLCipher key (hex passphrase or raw ASCII — both work).
+   * Omit (or set to an empty string) for already-decrypted plain SQLite databases.
+   */
+  key?: string;
+  /**
+   * Cryptographic algorithms used for this database.
+   * Omit for plain (already-decrypted) databases.
+   */
+  algo?: DatabaseAlgorithms;
 }
 
 export class QqDb {
   readonly dbPath: string;
-  private readonly key: string;
-  private readonly algo: DatabaseAlgorithms;
+  private readonly key?: string;
+  private readonly algo?: DatabaseAlgorithms;
   private readonly nt: NtHelperBinding;
+  private readonly encrypted: boolean;
 
   constructor(nt: NtHelperBinding, opts: QqDbOptions) {
     this.nt = nt;
     this.dbPath = opts.dbPath;
     this.key = opts.key;
     this.algo = opts.algo;
+    this.encrypted = !!opts.key && !!opts.algo;
   }
 
   /**
@@ -46,7 +54,10 @@ export class QqDb {
    * static column list and prefer named access.
    */
   query(sql: string, params?: SqlValue[]): Promise<SqlRow[]> {
-    return this.nt.executeSqlWithKey(this.dbPath, sql, this.key, this.algo, params ?? null);
+    if (this.encrypted) {
+      return this.nt.executeSqlWithKey(this.dbPath, sql, this.key!, this.algo!, params ?? null);
+    }
+    return this.nt.executeSql(this.dbPath, sql, params ?? null);
   }
 
   /**
@@ -56,7 +67,10 @@ export class QqDb {
    *    run with QQ fully closed.
    */
   write(sql: string, params?: SqlValue[]): Promise<number> {
-    return this.nt.executeSqlWriteWithKey(this.dbPath, sql, this.key, this.algo, params ?? null);
+    if (this.encrypted) {
+      return this.nt.executeSqlWriteWithKey(this.dbPath, sql, this.key!, this.algo!, params ?? null);
+    }
+    return this.nt.executeSqlWrite(this.dbPath, sql, params ?? null);
   }
 
   /** Drop both the read and write cached native connections for this database. */

--- a/packages/service/src/account/user_config.ts
+++ b/packages/service/src/account/user_config.ts
@@ -75,7 +75,15 @@ export interface AccountConfig {
    */
   configId: string;
   uin: string;
+  /**
+   * SQLCipher key. Empty string for already-decrypted static accounts that
+   * opened without a key (the record is always written with at least '').
+   */
   dbKey: string;
+  /**
+   * Cryptographic algorithms used for this account's databases. Empty
+   * strings for plain (already-decrypted) static accounts.
+   */
   algo: DatabaseAlgorithms;
   /**
    * Absolute path to this account's user-data directory
@@ -100,6 +108,13 @@ export interface AccountConfig {
   rkeyUpdatedAt?: number;
   /** Latest clientkey harvested from the online instance (when 自动获取 ClientKey is on). */
   clientKey?: ClientKey;
+  /**
+   * True for static / offline accounts opened from a directory of
+   * already-decrypted (or SQLCipher-keyed) databases. Drives the
+   * 「静态」 badge in the account list and chooses `setStaticAccount`
+   * vs `setAccount` on re-open.
+   */
+  static?: boolean;
 }
 
 /** Metadata threaded in from the open flow to enrich the saved record. */
@@ -107,6 +122,9 @@ export interface AccountConfigMetadata {
   displayName?: string;
   avatarUrl?: string;
   dataDir?: string;
+  /** Set when opening a static (offline) account so the badge / re-open
+   *  path know which flow to use. */
+  static?: boolean;
 }
 
 /**
@@ -168,6 +186,7 @@ export class AccountConfigService {
       ...(metadata.dataDir ? { dataDir: metadata.dataDir } : {}),
       ...(metadata.displayName ? { displayName: metadata.displayName } : {}),
       ...(metadata.avatarUrl ? { avatarUrl: metadata.avatarUrl } : {}),
+      ...(metadata.static === true ? { static: true } : {}),
       lastLoginAt: Date.now(),
     };
     this.writeRecord(config);


### PR DESCRIPTION
Summary

新增本地离线数据库读取功能：无需 QQ 密钥和在线进程，可直接打开已解密的数据库目录，以离线静态模式查看消息、群组、联系人等数据。
同时新增初始界面的窗口关闭按钮。

- 首页新增第三个入口卡片："本地已解密数据库读取"
- 点击"本地已解密数据库读取" → 选择含 nt_msg.db 的目录
- 新增首页窗口关闭按钮