### PR TITLE
Feat: 群聊分析

### DIFF
--- a/apps/desktop/src/main/ipc/routers/account.ts
+++ b/apps/desktop/src/main/ipc/routers/account.ts
@@ -742,6 +742,60 @@ export const accountRouter = router({
       return groups.map(groupMemberToWire);
     }),
 
+  getGroupMessageRanking: procedure
+    .input(
+      z.object({
+        groupCode: z.string().min(1),
+        limit: z.number().int().min(1).max(100).optional(),
+        startTime: z.number().int().optional(),
+        endTime: z.number().int().optional(),
+      }),
+    )
+    .query(async ({ input }) => {
+      return requireServices().groupInfo.getGroupMessageRanking(
+        BigInt(input.groupCode),
+        input.limit ?? 20,
+        input.startTime,
+        input.endTime,
+      );
+    }),
+
+  /** 24-hour activity distribution for a group. */
+  getGroupActiveHours: procedure
+    .input(
+      z.object({
+        groupCode: z.string().min(1),
+        startTime: z.number().int().optional(),
+        endTime: z.number().int().optional(),
+      }),
+    )
+    .query(async ({ input }) => {
+      return requireServices().groupInfo.getGroupActiveHours(
+        BigInt(input.groupCode),
+        input.startTime,
+        input.endTime,
+      );
+    }),
+
+  /** Detailed per-member analytics for a group. */
+  getGroupMemberAnalytics: procedure
+    .input(
+      z.object({
+        groupCode: z.string().min(1),
+        memberUid: z.string().min(1),
+        startTime: z.number().int().optional(),
+        endTime: z.number().int().optional(),
+      }),
+    )
+    .query(async ({ input }) => {
+      return requireServices().groupInfo.getGroupMemberAnalytics(
+        BigInt(input.groupCode),
+        input.memberUid,
+        input.startTime,
+        input.endTime,
+      );
+    }),
+
   /** Get formatted online status for a user. */
   getOnlineStatus: procedure
     .input(z.object({ uid: z.string().min(1) }))

--- a/apps/desktop/src/renderer/src/components/GroupAnalyticsDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/GroupAnalyticsDialog.tsx
@@ -1,0 +1,581 @@
+// @ts-nocheck
+import {
+  BarChart3,
+  ChevronLeft,
+  Clock,
+  Loader2,
+  Medal,
+  MessageSquare,
+  Search,
+  Users,
+  X,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { client } from "../trpc/client";
+import { Avatar } from "../im-template/template/primitives";
+import { cn } from "../im-template/template/classNames";
+import { closeFromScrim, useEscapeToClose } from "../im-template/template/modalUtils";
+
+interface MemberWire {
+  uid: string;
+  uin: string;
+  card: string;
+  nick: string;
+  joinTime: number;
+  lastSpeakTime: number;
+  adminFlag: number;
+  customTitle: string;
+  memberLevel: number;
+}
+
+interface RankingItem {
+  uid: string;
+  uin: string;
+  displayName: string;
+  messageCount: number;
+}
+
+interface MemberAnalyticsData {
+  statistics: {
+    totalMessages: number;
+    textMessages: number;
+    imageMessages: number;
+    voiceMessages: number;
+    videoMessages: number;
+    emojiMessages: number;
+    otherMessages: number;
+    firstMessageTime: number | null;
+    lastMessageTime: number | null;
+    activeDays: number;
+  };
+  timeDistribution: Record<number, number>;
+  commonPhrases: Array<{ phrase: string; count: number }>;
+  commonEmojis: Array<{ emoji: string; count: number }>;
+}
+
+type View = "menu" | "members" | "memberAnalytics" | "ranking" | "activeHours";
+
+function formatNumber(n: number): string {
+  if (n >= 10000) return `${(n / 10000).toFixed(1)}万`;
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+function formatDate(ts: number | null): string {
+  if (!ts) return "-";
+  const d = new Date(ts * 1000);
+  return `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+function memberDisplayName(m: MemberWire): string {
+  return m.card || m.nick || m.uin || m.uid || "?";
+}
+
+function memberAvatarUrl(m: MemberWire): string | null {
+  if (m.uin && m.uin !== "0") {
+    return `https://thirdqq.qlogo.cn/g?b=sdk&nk=${m.uin}&s=0`;
+  }
+  return null;
+}
+
+function HourlyBarChart({
+  data,
+  color = "#07c160",
+}: {
+  data: Record<number, number>;
+  color?: string;
+}) {
+  const max = Math.max(...Object.values(data), 1);
+  return (
+    <div className="ga-bar-chart">
+      {Array.from({ length: 24 }, (_, hour) => {
+        const value = data[hour] ?? 0;
+        const heightPct = max > 0 ? (value / max) * 100 : 0;
+        return (
+          <div className="ga-bar-col" key={hour}>
+            <div className="ga-bar-value-label">
+              {value > 0 ? formatNumber(value) : ""}
+            </div>
+            <div className="ga-bar-track">
+              <div
+                className="ga-bar-fill"
+                style={{
+                  height: `${Math.max(heightPct, value > 0 ? 2 : 0)}%`,
+                  backgroundColor: color,
+                }}
+              />
+            </div>
+            <div className="ga-bar-hour-label">{hour}时</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function GroupAnalyticsDialog({
+  groupCode,
+  groupName,
+  onClose,
+}: {
+  groupCode: string;
+  groupName: string;
+  onClose: () => void;
+}) {
+  useEscapeToClose(onClose);
+
+  const [view, setView] = useState<View>("menu");
+  const [members, setMembers] = useState<MemberWire[]>([]);
+  const [membersLoading, setMembersLoading] = useState(false);
+  const [membersError, setMembersError] = useState<string | null>(null);
+
+  const [ranking, setRanking] = useState<RankingItem[]>([]);
+  const [rankingLoading, setRankingLoading] = useState(false);
+  const [rankingError, setRankingError] = useState<string | null>(null);
+
+  const [activeHours, setActiveHours] = useState<Record<number, number> | null>(null);
+  const [activeHoursLoading, setActiveHoursLoading] = useState(false);
+  const [activeHoursError, setActiveHoursError] = useState<string | null>(null);
+
+  const [selectedMemberUid, setSelectedMemberUid] = useState<string>("");
+  const [memberSearch, setMemberSearch] = useState("");
+  const [memberAnalytics, setMemberAnalytics] = useState<MemberAnalyticsData | null>(null);
+  const [memberAnalyticsLoading, setMemberAnalyticsLoading] = useState(false);
+  const [memberAnalyticsError, setMemberAnalyticsError] = useState<string | null>(null);
+
+  const selectedMember = useMemo(
+    () => members.find((m) => m.uid === selectedMemberUid) ?? null,
+    [members, selectedMemberUid],
+  );
+
+  const loadMembers = useCallback(async () => {
+    setMembersLoading(true);
+    setMembersError(null);
+    try {
+      const result = await client.account.listGroupMembers.query({
+        groupCode,
+        limit: 300,
+      });
+      setMembers(result as MemberWire[]);
+    } catch (e) {
+      setMembersError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setMembersLoading(false);
+    }
+  }, [groupCode]);
+
+  useEffect(() => {
+    void loadMembers();
+  }, [loadMembers]);
+
+  const loadRanking = useCallback(async () => {
+    setRankingLoading(true);
+    setRankingError(null);
+    try {
+      const result = await client.account.getGroupMessageRanking.query({ groupCode });
+      setRanking(result as RankingItem[]);
+    } catch (e) {
+      setRankingError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRankingLoading(false);
+    }
+  }, [groupCode]);
+
+  const loadActiveHours = useCallback(async () => {
+    setActiveHoursLoading(true);
+    setActiveHoursError(null);
+    try {
+      const result = await client.account.getGroupActiveHours.query({ groupCode });
+      setActiveHours(result as Record<number, number>);
+    } catch (e) {
+      setActiveHoursError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setActiveHoursLoading(false);
+    }
+  }, [groupCode]);
+
+  const loadMemberAnalytics = useCallback(
+    async (uid: string) => {
+      setSelectedMemberUid(uid);
+      setMemberAnalyticsLoading(true);
+      setMemberAnalyticsError(null);
+      setMemberAnalytics(null);
+      try {
+        const result = await client.account.getGroupMemberAnalytics.query({
+          groupCode,
+          memberUid: uid,
+        });
+        setMemberAnalytics(result as MemberAnalyticsData);
+      } catch (e) {
+        setMemberAnalyticsError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setMemberAnalyticsLoading(false);
+      }
+    },
+    [groupCode],
+  );
+
+  const goTo = useCallback(
+    (v: View) => {
+      setView(v);
+      if (v === "ranking" && ranking.length === 0 && !rankingLoading) void loadRanking();
+      if (v === "activeHours" && !activeHours && !activeHoursLoading) void loadActiveHours();
+    },
+    [view, ranking, rankingLoading, activeHours, activeHoursLoading, loadRanking, loadActiveHours],
+  );
+
+  const filteredMembers = useMemo(() => {
+    if (!memberSearch.trim()) return members;
+    const kw = memberSearch.trim().toLowerCase();
+    return members.filter(
+      (m) =>
+        (m.card || "").toLowerCase().includes(kw) ||
+        (m.nick || "").toLowerCase().includes(kw) ||
+        (m.uin || "").includes(kw) ||
+        (m.uid || "").toLowerCase().includes(kw),
+    );
+  }, [members, memberSearch]);
+
+  const title = (() => {
+    switch (view) {
+      case "members":
+        return "群成员查看";
+      case "memberAnalytics":
+        return "群成员详细分析";
+      case "ranking":
+        return "群聊发言排行";
+      case "activeHours":
+        return "群聊活跃时段";
+      default:
+        return "群聊分析";
+    }
+  })();
+
+  return (
+    <div
+      className="modal-scrim group-album-scrim"
+      role="presentation"
+      onMouseDown={closeFromScrim(onClose)}
+    >
+      <section
+        className="group-album-dialog ga-dialog"
+        role="dialog"
+        aria-modal="true"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <header>
+          <div>
+            {view !== "menu" && (
+              <button
+                className="icon-button"
+                type="button"
+                title="返回"
+                onClick={() => {
+                  setView("menu");
+                  setMemberSearch("");
+                }}
+                style={{ marginRight: 8 }}
+              >
+                <ChevronLeft size={18} />
+              </button>
+            )}
+            <strong>{title}</strong>
+            <span>{groupName}</span>
+          </div>
+          <button className="icon-button" type="button" title="关闭" onClick={onClose}>
+            <X size={18} />
+          </button>
+        </header>
+
+        <div className="group-album-body ga-body">
+          {view === "menu" && (
+            <div className="ga-menu-grid">
+              <button className="ga-menu-card" type="button" onClick={() => goTo("members")}>
+                <Users size={28} />
+                <span>群成员查看</span>
+                <small>查看群成员列表和基础资料</small>
+              </button>
+              <button
+                className="ga-menu-card"
+                type="button"
+                onClick={() => goTo("memberAnalytics")}
+              >
+                <BarChart3 size={28} />
+                <span>群成员详细分析</span>
+                <small>分析某个成员的发言数量、活跃周期、常用语</small>
+              </button>
+              <button className="ga-menu-card" type="button" onClick={() => goTo("ranking")}>
+                <Medal size={28} />
+                <span>群聊发言排行</span>
+                <small>统计成员发言数量排行</small>
+              </button>
+              <button className="ga-menu-card" type="button" onClick={() => goTo("activeHours")}>
+                <Clock size={28} />
+                <span>群聊活跃时段</span>
+                <small>查看全天活跃时间分布</small>
+              </button>
+            </div>
+          )}
+
+          {view === "members" && (
+            <div className="ga-members">
+              {membersLoading ? (
+                <div className="ga-loading">
+                  <Loader2 size={28} className="weq-spin" />
+                </div>
+              ) : membersError ? (
+                <div className="ga-error">{membersError}</div>
+              ) : (
+                <div className="ga-members-grid">
+                  {members.map((m) => (
+                    <button
+                      key={m.uid}
+                      className="ga-member-card"
+                      type="button"
+                      onClick={() => {
+                        setSelectedMemberUid(m.uid);
+                        setMemberAnalytics(null);
+                        setMemberAnalyticsError(null);
+                        setView("memberAnalytics");
+                        void loadMemberAnalytics(m.uid);
+                      }}
+                    >
+                      <Avatar name={memberDisplayName(m)} avatarUrl={memberAvatarUrl(m)} />
+                      <span className="ga-member-name">{memberDisplayName(m)}</span>
+                      {m.uin && m.uin !== "0" ? (
+                        <span className="ga-member-uin">{m.uin}</span>
+                      ) : null}
+                      {m.memberLevel > 0 && (
+                        <span className="ga-member-level">LV{m.memberLevel}</span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {view === "memberAnalytics" && (
+            <div className="ga-member-analytics">
+              {/* Member selector */}
+              <div className="ga-member-select-row">
+                <div className="ga-search-wrap">
+                  <Search size={14} />
+                  <input
+                    type="text"
+                    placeholder="搜索成员昵称 / QQ号"
+                    value={memberSearch}
+                    onChange={(e) => setMemberSearch(e.target.value)}
+                  />
+                </div>
+              </div>
+
+              {/* Selected member chip */}
+              {selectedMember ? (
+                <div className="ga-selected-member">
+                  <Avatar name={memberDisplayName(selectedMember)} avatarUrl={memberAvatarUrl(selectedMember)} />
+                  <div>
+                    <strong>{memberDisplayName(selectedMember)}</strong>
+                    {selectedMember.uin && selectedMember.uin !== "0" ? (
+                      <small>QQ: {selectedMember.uin}</small>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
+
+              {/* Member search list */}
+              {memberSearch.trim() ? (
+                <div className="ga-member-search-list">
+                  {filteredMembers.slice(0, 30).map((m) => (
+                    <button
+                      key={m.uid}
+                      className={cn(
+                        "ga-member-search-item",
+                        selectedMemberUid === m.uid && "active",
+                      )}
+                      type="button"
+                      onClick={() => {
+                        setMemberSearch("");
+                        void loadMemberAnalytics(m.uid);
+                      }}
+                    >
+                      <Avatar name={memberDisplayName(m)} avatarUrl={memberAvatarUrl(m)} />
+                      <span>{memberDisplayName(m)}</span>
+                      {m.uin ? <small>QQ: {m.uin}</small> : null}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+
+              {!selectedMember ? (
+                <p className="ga-placeholder">请搜索并选择一名成员进行分析</p>
+              ) : memberAnalyticsLoading ? (
+                <div className="ga-loading">
+                  <Loader2 size={28} className="weq-spin" />
+                </div>
+              ) : memberAnalyticsError ? (
+                <div className="ga-error">{memberAnalyticsError}</div>
+              ) : memberAnalytics ? (
+                <div className="ga-analytics-content">
+                  {/* Stats cards */}
+                  <div className="ga-stats-cards">
+                    <div className="ga-stat-card">
+                      <MessageSquare size={20} />
+                      <div>
+                        <strong>{formatNumber(memberAnalytics.statistics.totalMessages)}</strong>
+                        <span>发言数量</span>
+                      </div>
+                    </div>
+                    <div className="ga-stat-card">
+                      <Clock size={20} />
+                      <div>
+                        <strong>{memberAnalytics.statistics.activeDays}</strong>
+                        <span>活跃天数</span>
+                      </div>
+                    </div>
+                    <div className="ga-stat-card ga-stat-wide">
+                      <div>
+                        <strong>
+                          {formatDate(memberAnalytics.statistics.firstMessageTime)} —{" "}
+                          {formatDate(memberAnalytics.statistics.lastMessageTime)}
+                        </strong>
+                        <span>活跃周期</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Message type breakdown */}
+                  <div className="ga-type-breakdown">
+                    {[
+                      { label: "文本", count: memberAnalytics.statistics.textMessages, color: "#3b82f6" },
+                      { label: "图片", count: memberAnalytics.statistics.imageMessages, color: "#22c55e" },
+                      { label: "语音", count: memberAnalytics.statistics.voiceMessages, color: "#f97316" },
+                      { label: "视频", count: memberAnalytics.statistics.videoMessages, color: "#a855f7" },
+                      { label: "表情", count: memberAnalytics.statistics.emojiMessages, color: "#ec4899" },
+                      { label: "其他", count: memberAnalytics.statistics.otherMessages, color: "#6b7280" },
+                    ]
+                      .filter((x) => x.count > 0)
+                      .map((x) => (
+                        <div className="ga-type-chip" key={x.label}>
+                          <span
+                            className="ga-type-dot"
+                            style={{ backgroundColor: x.color }}
+                          />
+                          <span className="ga-type-label">{x.label}</span>
+                          <span className="ga-type-count">{x.count}</span>
+                        </div>
+                      ))}
+                  </div>
+
+                  {/* Hourly bar chart */}
+                  <div className="ga-section">
+                    <h3>活跃时段</h3>
+                    <HourlyBarChart data={memberAnalytics.timeDistribution} />
+                  </div>
+
+                  {/* Common phrases & emojis */}
+                  <div className="ga-section">
+                    <div className="ga-phrases-row">
+                      <div className="ga-phrases-col">
+                        <h3>常用语</h3>
+                        {memberAnalytics.commonPhrases.length > 0 ? (
+                          <div className="ga-chips">
+                            {memberAnalytics.commonPhrases.map((item, idx) => (
+                              <span className="ga-chip" key={idx}>
+                                <span>{item.phrase}</span>
+                                <small>{item.count}次</small>
+                              </span>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="ga-chip-empty">暂无常用语</span>
+                        )}
+                      </div>
+                      <div className="ga-phrases-col">
+                        <h3>常用表情</h3>
+                        {memberAnalytics.commonEmojis.length > 0 ? (
+                          <div className="ga-chips">
+                            {memberAnalytics.commonEmojis.map((item, idx) => (
+                              <span className="ga-chip" key={idx}>
+                                <span>{item.emoji}</span>
+                                <small>{item.count}次</small>
+                              </span>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="ga-chip-empty">暂无表情数据</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <p className="ga-placeholder">点击上方搜索列表中的成员开始分析</p>
+              )}
+            </div>
+          )}
+
+          {view === "ranking" && (
+            <div className="ga-ranking">
+              {rankingLoading ? (
+                <div className="ga-loading">
+                  <Loader2 size={28} className="weq-spin" />
+                </div>
+              ) : rankingError ? (
+                <div className="ga-error">{rankingError}</div>
+              ) : ranking.length === 0 ? (
+                <p className="ga-placeholder">暂无发言数据</p>
+              ) : (
+                <div className="ga-ranking-list">
+                  {ranking.map((item, idx) => (
+                    <div
+                      className={cn(
+                        "ga-ranking-item",
+                        idx === 0 && "rank-1",
+                        idx === 1 && "rank-2",
+                        idx === 2 && "rank-3",
+                      )}
+                      key={item.uid}
+                    >
+                      <span
+                        className={cn("ga-rank-num", idx < 3 && "top")}
+                      >
+                        {idx < 3 ? <Medal size={14} /> : idx + 1}
+                      </span>
+                      <Avatar
+                        name={item.displayName}
+                        avatarUrl={
+                          item.uin && item.uin !== "0"
+                            ? `https://thirdqq.qlogo.cn/g?b=sdk&nk=${item.uin}&s=0`
+                            : null
+                        }
+                      />
+                      <span className="ga-rank-name">{item.displayName}</span>
+                      <span className="ga-rank-count">
+                        {formatNumber(item.messageCount)} 条
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {view === "activeHours" && (
+            <div className="ga-active-hours">
+              {activeHoursLoading ? (
+                <div className="ga-loading">
+                  <Loader2 size={28} className="weq-spin" />
+                </div>
+              ) : activeHoursError ? (
+                <div className="ga-error">{activeHoursError}</div>
+              ) : activeHours ? (
+                <HourlyBarChart data={activeHours} />
+              ) : null}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/im-template/styles/chat.css
+++ b/apps/desktop/src/renderer/src/im-template/styles/chat.css
@@ -2756,3 +2756,455 @@ button.contact-profile-row:hover {
 .chat-header [role="button"] {
 	-webkit-app-region: no-drag;
 }
+
+/* ── Group Analytics Dialog ──────────────────────────────────────── */
+
+.ga-dialog {
+	width: 620px;
+	max-width: 92vw;
+	max-height: 90vh;
+}
+
+.ga-body {
+	min-height: 320px;
+}
+
+/* menu grid */
+
+.ga-menu-grid {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr);
+	gap: 14px;
+	padding: 8px 0;
+}
+
+.ga-menu-card {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+	padding: 28px 16px 22px;
+	border: 1px solid #e5e5e5;
+	border-radius: 12px;
+	background: #fff;
+	cursor: pointer;
+	text-align: center;
+	transition: border-color 0.15s, background 0.15s;
+}
+
+.ga-menu-card:hover {
+	border-color: rgba(0, 153, 247, 0.35);
+	background: #f8fcff;
+}
+
+.ga-menu-card span {
+	font-size: 15px;
+	font-weight: 600;
+	color: #1a1a1a;
+}
+
+.ga-menu-card small {
+	font-size: 12px;
+	color: #8a8a8a;
+	line-height: 1.4;
+}
+
+/* loading / error / placeholder */
+
+.ga-loading {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 48px 0;
+	color: #8a8a8a;
+}
+
+.ga-error {
+	color: #e53e3e;
+	padding: 16px;
+	text-align: center;
+	font-size: 13px;
+}
+
+.ga-placeholder {
+	color: #8a8a8a;
+	text-align: center;
+	padding: 40px 0;
+	font-size: 13px;
+}
+
+/* members grid */
+
+.ga-members-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+	gap: 14px 10px;
+	padding: 4px 0;
+}
+
+.ga-member-card {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 4px;
+	border: none;
+	border-radius: 10px;
+	background: transparent;
+	cursor: pointer;
+	transition: background 0.12s;
+}
+
+.ga-member-card:hover {
+	background: #f2f3f5;
+}
+
+.ga-member-name {
+	font-size: 12px;
+	color: #333;
+	text-align: center;
+	word-break: break-all;
+	line-height: 1.3;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+}
+
+.ga-member-uin {
+	font-size: 10px;
+	color: #8a8a8a;
+	word-break: break-all;
+}
+
+.ga-member-level {
+	font-size: 10px;
+	color: #0099f7;
+	font-weight: 600;
+}
+
+/* member analytics */
+
+.ga-member-select-row {
+	margin-bottom: 10px;
+}
+
+.ga-search-wrap {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 12px;
+	border: 1px solid #e0e0e0;
+	border-radius: 8px;
+	background: #fff;
+}
+
+.ga-search-wrap input {
+	border: none;
+	outline: none;
+	flex: 1;
+	font-size: 13px;
+	background: transparent;
+}
+
+.ga-selected-member {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 16px;
+	padding: 10px 14px;
+	background: #f5faff;
+	border-radius: 10px;
+	border: 1px solid rgba(0, 153, 247, 0.18);
+}
+
+.ga-selected-member > div {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.ga-selected-member strong {
+	font-size: 14px;
+}
+
+.ga-selected-member small {
+	font-size: 11px;
+	color: #8a8a8a;
+}
+
+.ga-member-search-list {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	margin-bottom: 16px;
+	max-height: 200px;
+	overflow: auto;
+	border: 1px solid #e0e0e0;
+	border-radius: 8px;
+}
+
+.ga-member-search-item {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 8px 12px;
+	border: none;
+	background: #fff;
+	cursor: pointer;
+	font-size: 13px;
+	text-align: left;
+}
+
+.ga-member-search-item:hover {
+	background: #f2f3f5;
+}
+
+.ga-member-search-item.active {
+	background: #e8f4fd;
+}
+
+.ga-member-search-item small {
+	font-size: 11px;
+	color: #8a8a8a;
+	margin-left: auto;
+}
+
+/* stats cards */
+
+.ga-stats-cards {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 10px;
+	margin-bottom: 14px;
+}
+
+.ga-stat-card {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 14px 16px;
+	background: #f7f8fa;
+	border-radius: 10px;
+}
+
+.ga-stat-card strong {
+	font-size: 16px;
+	display: block;
+	color: #1a1a1a;
+}
+
+.ga-stat-card span {
+	font-size: 11px;
+	color: #8a8a8a;
+}
+
+.ga-stat-wide {
+	grid-column: span 2;
+}
+
+/* type breakdown */
+
+.ga-type-breakdown {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-bottom: 14px;
+}
+
+.ga-type-chip {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 12px;
+	border: 1px solid #e5e5e5;
+	border-radius: 8px;
+	font-size: 12px;
+}
+
+.ga-type-dot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+}
+
+.ga-type-label {
+	color: #333;
+}
+
+.ga-type-count {
+	color: #8a8a8a;
+	font-weight: 600;
+}
+
+/* sections */
+
+.ga-section {
+	margin-bottom: 16px;
+}
+
+.ga-section h3 {
+	font-size: 14px;
+	font-weight: 600;
+	margin-bottom: 10px;
+}
+
+/* bar chart */
+
+.ga-bar-chart {
+	display: flex;
+	align-items: flex-end;
+	gap: 0;
+	height: 160px;
+	padding: 8px 0 0;
+	border-bottom: 1px solid #e5e5e5;
+}
+
+.ga-bar-col {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	height: 100%;
+}
+
+.ga-bar-value-label {
+	font-size: 9px;
+	color: #8a8a8a;
+	height: 16px;
+	line-height: 16px;
+	text-align: center;
+}
+
+.ga-bar-track {
+	flex: 1;
+	width: 75%;
+	max-width: 28px;
+	display: flex;
+	align-items: flex-end;
+	border-radius: 4px 4px 0 0;
+	background: #f0f0f0;
+}
+
+.ga-bar-fill {
+	width: 100%;
+	border-radius: 4px 4px 0 0;
+	min-height: 2px;
+	transition: height 0.3s ease;
+}
+
+.ga-bar-hour-label {
+	font-size: 10px;
+	color: #8a8a8a;
+	margin-top: 4px;
+	height: 18px;
+	line-height: 18px;
+}
+
+/* common phrases & emojis */
+
+.ga-phrases-row {
+	display: flex;
+	gap: 24px;
+}
+
+.ga-phrases-col {
+	flex: 1;
+	min-width: 0;
+}
+
+.ga-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.ga-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 12px;
+	background: #f7f8fa;
+	border: 1px solid #e5e5e5;
+	border-radius: 8px;
+	font-size: 13px;
+}
+
+.ga-chip small {
+	font-size: 11px;
+	color: #8a8a8a;
+}
+
+.ga-chip-empty {
+	font-size: 12px;
+	color: #8a8a8a;
+}
+
+/* ranking */
+
+.ga-ranking-list {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.ga-ranking-item {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 10px 14px;
+	border-radius: 10px;
+	background: #fff;
+	border: 1px solid transparent;
+	transition: background 0.12s;
+}
+
+.ga-ranking-item:hover {
+	background: #f8f9fb;
+}
+
+.ga-ranking-item.rank-1 {
+	background: linear-gradient(135deg, #fff9e6, #fff3cc);
+	border-color: #ffd700;
+}
+
+.ga-ranking-item.rank-2 {
+	background: linear-gradient(135deg, #f5f5f5, #e8e8e8);
+	border-color: #c0c0c0;
+}
+
+.ga-ranking-item.rank-3 {
+	background: linear-gradient(135deg, #fdf4ed, #fbe0c8);
+	border-color: #cd7f32;
+}
+
+.ga-rank-num {
+	width: 24px;
+	text-align: center;
+	font-size: 14px;
+	font-weight: 600;
+	color: #8a8a8a;
+}
+
+.ga-rank-num.top {
+	color: #1a1a1a;
+}
+
+.ga-rank-name {
+	flex: 1;
+	font-size: 13px;
+	font-weight: 500;
+	color: #333;
+}
+
+.ga-rank-count {
+	font-size: 13px;
+	font-weight: 600;
+	color: #1a1a1a;
+}
+
+/* active hours page */
+
+.ga-active-hours {
+	padding: 8px 0;
+}

--- a/apps/desktop/src/renderer/src/im-template/template/chatMainContent.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/chatMainContent.tsx
@@ -71,6 +71,7 @@ export function ChatMainContent({
 	onEditRaw,
 	onOpenGroupAlbums,
 	onOpenGroupAnnouncements,
+	onOpenGroupAnalytics,
 	onOpenTool,
 	onSelectTool,
 }: {
@@ -127,6 +128,7 @@ export function ChatMainContent({
 	onEditRaw?: (message: Message) => void;
 	onOpenGroupAlbums?: (conversation: GroupConversation) => void;
 	onOpenGroupAnnouncements?: (conversation: GroupConversation) => void;
+	onOpenGroupAnalytics?: (conversation: GroupConversation) => void;
 	onOpenTool?: (item: ToolPaneItem) => void;
 	onSelectTool?: (item: ToolPaneItem) => void;
 }) {
@@ -194,6 +196,7 @@ export function ChatMainContent({
 			onEditRaw={onEditRaw}
 			onOpenGroupAlbums={onOpenGroupAlbums}
 			onOpenGroupAnnouncements={onOpenGroupAnnouncements}
+			onOpenGroupAnalytics={onOpenGroupAnalytics}
 		/>
 	);
 }

--- a/apps/desktop/src/renderer/src/im-template/template/chatPane.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/chatPane.tsx
@@ -1,5 +1,6 @@
 ﻿// @ts-nocheck
 import {
+	BarChart3,
 	Bot,
 	ChevronDown,
 	ChevronLeft,
@@ -201,6 +202,7 @@ export function ChatPane({
 	onEditRaw,
 	onOpenGroupAlbums,
 	onOpenGroupAnnouncements,
+	onOpenGroupAnalytics,
 }: {
 	user: User;
 	conversation: Conversation | undefined;
@@ -227,6 +229,7 @@ export function ChatPane({
 	onEditRaw?: (message: Message) => void;
 	onOpenGroupAlbums?: (conversation: Extract<Conversation, { type: "group" }>) => void;
 	onOpenGroupAnnouncements?: (conversation: Extract<Conversation, { type: "group" }>) => void;
+	onOpenGroupAnalytics?: (conversation: Extract<Conversation, { type: "group" }>) => void;
 }) {
 	// 复用 replyJump 的跳转能力（含翻页/重建窗口），供群精华消息跳转使用。
 	const jumpToSeq = useContext(ReplyJumpContext);
@@ -1284,6 +1287,14 @@ export function ChatPane({
 								onClick={() => onOpenGroupAlbums?.(conversation)}
 							>
 								<Images size={18} />
+							</button>
+							<button
+								className={cn("icon-button", "group-header-info-action")}
+								type="button"
+								title="Group analytics"
+								onClick={() => onOpenGroupAnalytics?.(conversation)}
+							>
+								<BarChart3 size={18} />
 							</button>
 						</>
 					) : null}

--- a/apps/desktop/src/renderer/src/views/MainView.tsx
+++ b/apps/desktop/src/renderer/src/views/MainView.tsx
@@ -29,6 +29,7 @@ import { useGroupMemberResolver } from '../hooks/useGroupMemberResolver';
 import { RailAccountFooter } from '../components/RailAccountFooter';
 import { SettingsDialog } from '../components/SettingsDialog';
 import { GroupAlbumDialog } from '../components/GroupAlbumDialog';
+import { GroupAnalyticsDialog } from '../components/GroupAnalyticsDialog';
 import { RelationGraphView } from '../components/relationGraph/RelationGraphView';
 import { ExportView } from './ExportView';
 import {
@@ -1468,6 +1469,10 @@ export function MainView(): ReactElement {
     groupCode: string;
     groupName: string;
   } | null>(null);
+  const [analyticsDialog, setAnalyticsDialog] = useState<{
+    groupCode: string;
+    groupName: string;
+  } | null>(null);
   
   const [editorState, setEditorState] = useState<{ msgId: string, elements: any[] } | null>(null);
 
@@ -1509,6 +1514,13 @@ export function MainView(): ReactElement {
     setRequestedAnnouncementGroups((current) => (
       current[conversation.id] ? current : { ...current, [conversation.id]: true }
     ));
+  }, []);
+
+  const handleOpenGroupAnalytics = useCallback((conversation: Extract<Conversation, { type: 'group' }>) => {
+    setAnalyticsDialog({
+      groupCode: conversation.id,
+      groupName: conversation.group.name,
+    });
   }, []);
 
   const [onlineStatusByUid, setOnlineStatusByUid] = useState<Record<string, any>>({});
@@ -2670,6 +2682,7 @@ export function MainView(): ReactElement {
                 onEditRaw={handleEditRaw}
                 onOpenGroupAlbums={handleOpenGroupAlbums}
                 onOpenGroupAnnouncements={handleOpenGroupAnnouncements}
+                onOpenGroupAnalytics={handleOpenGroupAnalytics}
               />
             </div>
             <OverlayScrollbar
@@ -2702,6 +2715,13 @@ export function MainView(): ReactElement {
           groupCode={albumDialog.groupCode}
           groupName={albumDialog.groupName}
           onClose={() => setAlbumDialog(null)}
+        />
+      ) : null}
+      {analyticsDialog ? (
+        <GroupAnalyticsDialog
+          groupCode={analyticsDialog.groupCode}
+          groupName={analyticsDialog.groupName}
+          onClose={() => setAnalyticsDialog(null)}
         />
       ) : null}
       </ConvContext.Provider>

--- a/packages/db/src/msg/group.ts
+++ b/packages/db/src/msg/group.ts
@@ -17,7 +17,7 @@
  * order by 40003 to hit the `(40027,40003)` composite index.
  */
 
-import type { DatabaseAlgorithms, NtHelperBinding, SqlRow } from '@weq/native';
+import type { DatabaseAlgorithms, NtHelperBinding, SqlRow, SqlValue } from '@weq/native';
 import type { GroupMsg } from './types';
 import { decodeBody, decodeEmoji, toBigint, toStr } from './util';
 import { QqDb } from '../qq_db';
@@ -89,7 +89,7 @@ export class GroupMsgDb {
     endTime?: number,
   ): Promise<GroupMsg[]> {
     const conditions: string[] = [`"40027" = ?`, `"40003" > ?`];
-    const params: Array<unknown> = [targetGroupCode, afterSeq];
+    const params: SqlValue[] = [targetGroupCode, afterSeq];
     if (startTime != null && startTime > 0) {
       conditions.push(`"40050" >= ?`);
       params.push(BigInt(startTime));

--- a/packages/db/src/msg/group.ts
+++ b/packages/db/src/msg/group.ts
@@ -77,6 +77,38 @@ export class GroupMsgDb {
   }
 
   /**
+   * Batch-read messages oldest-first, starting from `afterSeq` (0n to begin).
+   * Optionally filters by sendTime range (unix seconds). Use for analytics /
+   * full-group scans that need to process every message in order.
+   */
+  async listBatch(
+    targetGroupCode: string,
+    afterSeq: bigint,
+    limit = 500,
+    startTime?: number,
+    endTime?: number,
+  ): Promise<GroupMsg[]> {
+    const conditions: string[] = [`"40027" = ?`, `"40003" > ?`];
+    const params: Array<unknown> = [targetGroupCode, afterSeq];
+    if (startTime != null && startTime > 0) {
+      conditions.push(`"40050" >= ?`);
+      params.push(BigInt(startTime));
+    }
+    if (endTime != null && endTime > 0) {
+      conditions.push(`"40050" <= ?`);
+      params.push(BigInt(endTime));
+    }
+    const rows = await this.qq.query(
+      `SELECT ${SELECT_COLUMNS} FROM group_msg_table
+        WHERE ${conditions.join(' AND ')}
+        ORDER BY "40003" ASC
+        LIMIT ?`,
+      [...params, BigInt(limit)],
+    );
+    return rows.map(rowToGroupMsg);
+  }
+
+  /**
    * Messages with seq >= `sinceSeq`, newest-first, capped at `limit`. The
    * "re-read the currently-loaded window" query — picks up new tail messages
    * plus in-place edits (recall / sticker reactions) within the window.

--- a/packages/service/src/account/group_info.ts
+++ b/packages/service/src/account/group_info.ts
@@ -313,7 +313,7 @@ export class GroupInfoService {
 
     let afterSeq = 0n;
     while (true) {
-      const batch = await db.listBatch(groupCode, afterSeq, 500, startTime, endTime);
+      const batch = await db.listBatch(String(groupCode), afterSeq, 500, startTime, endTime);
       if (batch.length === 0) break;
       for (const msg of batch) {
         const uid = msg.senderUid || '';
@@ -362,7 +362,7 @@ export class GroupInfoService {
 
     let afterSeq = 0n;
     while (true) {
-      const batch = await db.listBatch(groupCode, afterSeq, 500, startTime, endTime);
+      const batch = await db.listBatch(String(groupCode), afterSeq, 500, startTime, endTime);
       if (batch.length === 0) break;
       for (const msg of batch) {
         const sendTime = Number(msg.sendTime);
@@ -405,7 +405,7 @@ export class GroupInfoService {
 
     let afterSeq = 0n;
     while (true) {
-      const batch = await db.listBatch(groupCode, afterSeq, 500, startTime, endTime);
+      const batch = await db.listBatch(String(groupCode), afterSeq, 500, startTime, endTime);
       if (batch.length === 0) break;
       for (const msg of batch) {
         if (msg.senderUid !== memberUid) continue;

--- a/packages/service/src/account/group_info.ts
+++ b/packages/service/src/account/group_info.ts
@@ -13,6 +13,33 @@ import type {
 } from '@weq/db';
 import { GroupNotifyService } from './group_notify';
 
+/** Message count ranking entry. */
+export interface GroupMessageRankingItem {
+  uid: string;
+  uin: string;
+  displayName: string;
+  messageCount: number;
+}
+
+/** Per-member analytics result. */
+export interface GroupMemberAnalytics {
+  statistics: {
+    totalMessages: number;
+    textMessages: number;
+    imageMessages: number;
+    voiceMessages: number;
+    videoMessages: number;
+    emojiMessages: number;
+    otherMessages: number;
+    firstMessageTime: number | null;
+    lastMessageTime: number | null;
+    activeDays: number;
+  };
+  timeDistribution: Record<number, number>;
+  commonPhrases: Array<{ phrase: string; count: number }>;
+  commonEmojis: Array<{ emoji: string; count: number }>;
+}
+
 /** One user that shares ≥2 groups with me, for the relation graph. */
 export interface RelationGraphNode {
   uid: string;
@@ -272,5 +299,207 @@ export class GroupInfoService {
    */
   async listGroupNotifies(limit = 100, offset = 0): Promise<GroupNotify[]> {
     return this.groupNotifyService.listAllNotifications(limit, offset);
+  }
+
+  async getGroupMessageRanking(
+    groupCode: bigint,
+    limit = 20,
+    startTime?: number,
+    endTime?: number,
+  ): Promise<GroupMessageRankingItem[]> {
+    const db = this.session.groupMsgs;
+    const counts = new Map<string, number>(); // uid → count
+    const uins = new Map<string, string>(); // uid → uin
+
+    let afterSeq = 0n;
+    while (true) {
+      const batch = await db.listBatch(groupCode, afterSeq, 500, startTime, endTime);
+      if (batch.length === 0) break;
+      for (const msg of batch) {
+        const uid = msg.senderUid || '';
+        if (!uid) continue;
+        counts.set(uid, (counts.get(uid) ?? 0) + 1);
+        if (!uins.has(uid) && msg.senderUin > 0n) {
+          uins.set(uid, String(msg.senderUin));
+        }
+      }
+      afterSeq = batch[batch.length - 1]!.msgSeq;
+      if (batch.length < 500) break;
+    }
+
+    const sorted = [...counts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit);
+
+    // Batch-resolve display names
+    const uids = sorted.map(([uid]) => uid);
+    const memberMap = new Map<string, string>();
+    if (uids.length > 0) {
+      try {
+        const members = await this.session.groupMembers.getMembersByUids(groupCode, uids);
+        for (const m of members) {
+          memberMap.set(m.uid, m.card || m.nick || m.uid);
+        }
+      } catch { /* fall through, use uin/uid as name */ }
+    }
+
+    return sorted.map(([uid, messageCount]) => ({
+      uid,
+      uin: uins.get(uid) ?? '',
+      displayName: memberMap.get(uid) || uins.get(uid) || uid,
+      messageCount,
+    }));
+  }
+
+  async getGroupActiveHours(
+    groupCode: bigint,
+    startTime?: number,
+    endTime?: number,
+  ): Promise<Record<number, number>> {
+    const db = this.session.groupMsgs;
+    const hourly: Record<number, number> = {};
+    for (let i = 0; i < 24; i++) hourly[i] = 0;
+
+    let afterSeq = 0n;
+    while (true) {
+      const batch = await db.listBatch(groupCode, afterSeq, 500, startTime, endTime);
+      if (batch.length === 0) break;
+      for (const msg of batch) {
+        const sendTime = Number(msg.sendTime);
+        if (sendTime > 0) {
+          const hour = new Date(sendTime * 1000).getHours();
+          hourly[hour] = (hourly[hour] ?? 0) + 1;
+        }
+      }
+      afterSeq = batch[batch.length - 1]!.msgSeq;
+      if (batch.length < 500) break;
+    }
+    return hourly;
+  }
+
+  async getGroupMemberAnalytics(
+    groupCode: bigint,
+    memberUid: string,
+    startTime?: number,
+    endTime?: number,
+  ): Promise<GroupMemberAnalytics> {
+    const db = this.session.groupMsgs;
+    const stats = {
+      totalMessages: 0,
+      textMessages: 0,
+      imageMessages: 0,
+      voiceMessages: 0,
+      videoMessages: 0,
+      emojiMessages: 0,
+      otherMessages: 0,
+      firstMessageTime: null as number | null,
+      lastMessageTime: null as number | null,
+      activeDays: 0,
+    };
+
+    const hourly: Record<number, number> = {};
+    for (let i = 0; i < 24; i++) hourly[i] = 0;
+    const dailySet = new Set<string>();
+    const phraseCounts = new Map<string, number>();
+    const emojiCounts = new Map<string, number>();
+
+    let afterSeq = 0n;
+    while (true) {
+      const batch = await db.listBatch(groupCode, afterSeq, 500, startTime, endTime);
+      if (batch.length === 0) break;
+      for (const msg of batch) {
+        if (msg.senderUid !== memberUid) continue;
+
+        const sendTime = Number(msg.sendTime);
+        stats.totalMessages++;
+
+        // Classify by element kind
+        let hasText = false;
+        let hasImage = false;
+        let hasVoice = false;
+        let hasVideo = false;
+        let hasEmoji = false;
+
+        for (const el of msg.elements) {
+          switch (el.kind) {
+            case 'text':
+            case 'at':
+              hasText = true;
+              if (el.textContent) {
+                const text = (el.textContent as string).trim();
+                if (text && text.length <= 20) {
+                  phraseCounts.set(text, (phraseCounts.get(text) ?? 0) + 1);
+                }
+              }
+              break;
+            case 'pic':
+              hasImage = true;
+              break;
+            case 'ptt':
+              hasVoice = true;
+              break;
+            case 'video':
+              hasVideo = true;
+              break;
+            case 'face':
+              hasEmoji = true;
+              if (el.faceText) {
+                const faceText = String(el.faceText).trim();
+                if (faceText) {
+                  emojiCounts.set(faceText, (emojiCounts.get(faceText) ?? 0) + 1);
+                }
+              }
+              break;
+            case 'mface':
+            case 'emojiBounce':
+              hasEmoji = true;
+              break;
+          }
+        }
+
+        if (hasText) stats.textMessages++;
+        if (hasImage) stats.imageMessages++;
+        if (hasVoice) stats.voiceMessages++;
+        if (hasVideo) stats.videoMessages++;
+        if (hasEmoji) stats.emojiMessages++;
+        if (!hasText && !hasImage && !hasVoice && !hasVideo && !hasEmoji) {
+          stats.otherMessages++;
+        }
+
+        if (sendTime > 0) {
+          if (stats.firstMessageTime === null || sendTime < stats.firstMessageTime) {
+            stats.firstMessageTime = sendTime;
+          }
+          if (stats.lastMessageTime === null || sendTime > stats.lastMessageTime) {
+            stats.lastMessageTime = sendTime;
+          }
+          const d = new Date(sendTime * 1000);
+          const hour = d.getHours();
+          hourly[hour] = (hourly[hour] ?? 0) + 1;
+          dailySet.add(`${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`);
+        }
+      }
+      afterSeq = batch[batch.length - 1]!.msgSeq;
+      if (batch.length < 500) break;
+    }
+
+    stats.activeDays = dailySet.size;
+
+    const commonPhrases = [...phraseCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([phrase, count]) => ({ phrase, count }));
+
+    const commonEmojis = [...emojiCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([emoji, count]) => ({ emoji, count }));
+
+    return {
+      statistics: stats,
+      timeDistribution: hourly,
+      commonPhrases,
+      commonEmojis,
+    };
   }
 }


### PR DESCRIPTION
Summary
- 在群聊右上角新增"群聊分析"按钮
- 四个子视图：群成员查看、成员详细分析、发言排行、活跃时段

- 群成员查看：显示真实头像和 QQ 号
- 成员分析：点击成员自动加载发言统计、常用语、常用表情
- 发言排行：按消息数排序
- 活跃时段：24 小时柱状图