### PR TITLE
优化和修复一些问题

### DIFF
--- a/apps/desktop/src/main/context/app_context.ts
+++ b/apps/desktop/src/main/context/app_context.ts
@@ -71,6 +71,7 @@ import {
   RelatedEmojiResourceService,
   FileResourceService,
   MediaResourceService,
+  ResourceCleanupService,
   WebQueryService,
   GroupAlbumMediaService,
   DbWatchService,
@@ -305,6 +306,8 @@ export interface AccountServices {
   fileResource: FileResourceService;
   /** Browse the account's local media caches (PhotoWall / Qzone / Pic / Video). */
   mediaResource: MediaResourceService;
+  /** Clean up the account's nt_data resource trees (本地资源整理 → 清理释放). */
+  resourceCleanup: ResourceCleanupService;
   /** Web CGI queries that need the already-hooked online QQ process. */
   webQuery: WebQueryService;
   /** Group album media listing over the already-hooked online QQ process. */
@@ -694,6 +697,7 @@ export function initAppContext(): AppContext {
         relatedEmoji: new RelatedEmojiResourceService(session, platform),
         fileResource: new FileResourceService(session, platform),
         mediaResource: new MediaResourceService(session, platform),
+        resourceCleanup: new ResourceCleanupService(session, platform),
         webQuery,
         groupAlbumMedia: new GroupAlbumMediaService(platform.native.ntHelper, session, resolveOnlinePid),
       };
@@ -931,6 +935,7 @@ export function initAppContext(): AppContext {
         relatedEmoji: new RelatedEmojiResourceService(session, platform),
         fileResource: new FileResourceService(session, platform),
         mediaResource: new MediaResourceService(session, platform),
+        resourceCleanup: new ResourceCleanupService(session, platform),
         webQuery,
         groupAlbumMedia: new GroupAlbumMediaService(platform.native.ntHelper, session, noPid),
       };

--- a/apps/desktop/src/main/context/app_context.ts
+++ b/apps/desktop/src/main/context/app_context.ts
@@ -686,6 +686,55 @@ export function initAppContext(): AppContext {
             },
             // 好友 QQ 空间说说导出：翻页拉取能力（需在线 QQ）。
             qzone: { fetchMsgList: (uin, pos, num) => webQuery.getQzoneMsgList(uin, pos, num) },
+            // 联系人导出（好友 / 群成员）：本地资料库拉取，bigint 归一化为字符串。
+            contacts: {
+              listBuddies: async (limit, offset) => {
+                const buddies = await profile.listBuddies(limit, offset);
+                return buddies.map((b) => ({
+                  uid: b.uid,
+                  uin: b.uin.toString(),
+                  qid: b.qid,
+                  categoryId: b.categoryId,
+                }));
+              },
+              listCategories: async () => {
+                const cats = await profile.listCategories();
+                return cats.map((c) => ({ id: c.id, name: c.name }));
+              },
+              profilesByUids: async (uids) => {
+                const profiles = await profile.profilesByUids(uids);
+                return profiles.map((p) => ({
+                  uid: p.uid,
+                  nick: p.nick,
+                  remark: p.remark,
+                  signature: p.signature,
+                  gender: p.gender,
+                  age: p.age,
+                  birthYear: p.birthYear,
+                  birthMonth: p.birthMonth,
+                  birthDay: p.birthDay,
+                  intimacy: p.intimacy,
+                }));
+              },
+              listGroupMembers: async (groupCode, limit, offset) => {
+                const members = await groupInfo.listMembersInGroup(BigInt(groupCode), limit, offset);
+                return members.map((m) => ({
+                  uid: m.uid,
+                  uin: m.uin.toString(),
+                  card: m.card,
+                  nick: m.nick,
+                  adminFlag: m.adminFlag,
+                  customTitle: m.customTitle,
+                  memberLevel: m.memberLevel,
+                  joinTime: m.joinTime,
+                  lastSpeakTime: m.lastSpeakTime,
+                }));
+              },
+              groupOwnerUid: async (groupCode) => {
+                const detail = await groupInfo.getGroupDetail(BigInt(groupCode));
+                return detail?.ownerUid ?? null;
+              },
+            },
           },
         ),
         dbDecrypt: new DbDecryptService(session, platform),

--- a/apps/desktop/src/main/ipc/routers/account.ts
+++ b/apps/desktop/src/main/ipc/routers/account.ts
@@ -29,6 +29,7 @@ import { customEmojiRouter } from './custom_emoji';
 import { relatedEmojiRouter } from './related_emoji';
 import { fileResourceRouter } from './file_resource';
 import { mediaResourceRouter } from './media_resource';
+import { resourceCleanupRouter } from './resource_cleanup';
 import { assistantBus, type AssistantStreamEvent } from '../../mcp/assistant_bus';
 import { groupChatBus, type GroupChatStreamEvent } from '../../mcp/agentlab_group_bus';
 import {
@@ -572,6 +573,8 @@ export const accountRouter = router({
   fileResource: fileResourceRouter,
   // ---- 图片墙 / QQ空间 / 图片 / 视频 local media cache browser ----
   mediaResource: mediaResourceRouter,
+  // ---- nt_data 资源清理释放 (本地资源整理 → 清理释放) ----
+  resourceCleanup: resourceCleanupRouter,
 
   // ---- agent lab ----
 

--- a/apps/desktop/src/main/ipc/routers/account.ts
+++ b/apps/desktop/src/main/ipc/routers/account.ts
@@ -1736,12 +1736,24 @@ export const accountRouter = router({
   /** List conversations with message counts (batch query). */
   listConversationsWithCount: procedure.query(async () => {
     const services = requireServices();
-    const contacts = await services.recentContacts.getRecentContact(200);
+    // 空 targetUid 的系统/占位会话既不能当消息分区键，也不是可导出目标 —— 直接剔除。
+    const contacts = (await services.recentContacts.getRecentContact(200)).filter(c => c.targetUid);
 
-    const groupCodes = contacts.filter(c => String(c.chatType).includes('GROUP')).map(c => c.targetUid);
-    const c2cUids = contacts.filter(c => String(c.chatType).includes('C2C')).map(c => c.targetUid);
-    // 数据线（我的手机/我的电脑）消息在 dataline_msg_table，单独计数。
-    const datalineUids = contacts.filter(c => String(c.chatType).includes('DATALINE')).map(c => c.targetUid);
+    // 分类是收集查询集和计数分流的唯一依据，两处必须共用，否则会出现
+    // 「归到 c2c 计数、却没被 countByUids 查过」的会话恒显示 0 条 —— 公众号
+    // (KCHATTYPETEMPPUBLICACCOUNT=103) 等枚举名不含 'C2C' 的临时会话就是这样：
+    // 消息其实在 c2c_msg_table，只是没进查询集。dataline 走独立表单独计数，
+    // 其余一切都按 c2c 归类（能查到就显示真实条数，查不到才是 0）。
+    const kindOf = (chatType: string | number): 'group' | 'dataline' | 'c2c' => {
+      const t = String(chatType);
+      if (t.includes('GROUP')) return 'group';
+      if (t.includes('DATALINE')) return 'dataline';
+      return 'c2c';
+    };
+
+    const groupCodes = contacts.filter(c => kindOf(c.chatType) === 'group').map(c => c.targetUid);
+    const c2cUids = contacts.filter(c => kindOf(c.chatType) === 'c2c').map(c => c.targetUid);
+    const datalineUids = contacts.filter(c => kindOf(c.chatType) === 'dataline').map(c => c.targetUid);
 
     const account = getAppContext().account;
     const [groupCounts, c2cCounts, datalineCounts] = await Promise.all([
@@ -1751,10 +1763,10 @@ export const accountRouter = router({
     ]);
 
     return contacts.map(c => {
-      const t = String(c.chatType);
-      const messageCount = t.includes('GROUP')
+      const kind = kindOf(c.chatType);
+      const messageCount = kind === 'group'
         ? (groupCounts[c.targetUid] ?? 0)
-        : t.includes('DATALINE')
+        : kind === 'dataline'
           ? (datalineCounts[c.targetUid] ?? 0)
           : (c2cCounts[c.targetUid] ?? 0);
       return { ...recentContactToWire(c), messageCount };

--- a/apps/desktop/src/main/ipc/routers/account.ts
+++ b/apps/desktop/src/main/ipc/routers/account.ts
@@ -1110,14 +1110,14 @@ export const accountRouter = router({
       if (!result) return null;
       return {
         msgSeq: result.msgSeq?.toString(),
-        // 特别关心标记（若该会话有特别关心未读）。seq 保留供上层使用。
-        specialCare: result.specialCare
-          ? {
-              msgSeq: result.specialCare.msgSeq.toString(),
-              senderUid: result.specialCare.senderUid,
-              sendTime: result.specialCare.sendTime.toString(),
-            }
-          : undefined,
+        // 提醒高亮（特别关心 / @我 / …）。各类别一条，seq 保留供上层使用。
+        highlights: result.highlights?.map((h) => ({
+          kind: h.kind,
+          rawKind: h.rawKind,
+          msgSeq: h.msgSeq.toString(),
+          senderUid: h.senderUid,
+          sendTime: h.sendTime.toString(),
+        })),
       };
     }),
 

--- a/apps/desktop/src/main/ipc/routers/account.ts
+++ b/apps/desktop/src/main/ipc/routers/account.ts
@@ -1850,6 +1850,40 @@ export const accountRouter = router({
     }),
 
   /**
+   * Start a contacts export — 好友列表（scope='friends'，可按分组过滤）或某群的
+   * 成员列表（scope='group'，`groupCode` 必填）。走本地资料库，无需在线 QQ。
+   * 好友支持 vcard；群成员不支持 vcard。
+   */
+  startContactsExport: procedure
+    .input(z.object({
+      scope: z.enum(['friends', 'group']),
+      groupCode: z.string().optional(),
+      name: z.string().min(1),
+      format: z.enum(['json', 'csv', 'xlsx', 'txt', 'vcard']),
+      exportAvatar: z.boolean().optional(),
+      categoryIds: z.array(z.number().int()).optional(),
+    }))
+    .mutation(async ({ input }) => {
+      if (input.scope === 'group' && !input.groupCode) {
+        throw new Error('导出群成员需要指定群号。');
+      }
+      // vcard 仅好友可用；群成员传 vcard 时回退到 csv。
+      const format = input.scope === 'group' && input.format === 'vcard' ? 'csv' : input.format;
+      return requireServices().exportManager.startTask({
+        contacts: {
+          scope: input.scope,
+          ...(input.categoryIds ? { categoryIds: input.categoryIds } : {}),
+        },
+        kind: 'c2c',
+        conv: input.scope === 'group' ? input.groupCode! : '',
+        name: input.name,
+        format,
+        total: 0,
+        exportAvatar: input.exportAvatar ?? false,
+      });
+    }),
+
+  /**
    * Force a one-shot rkey harvest from the online QQ for the open account — the
    * explicit "立即重新获取 rkey" before a media-completing export. Returns true
    * when fresh rkeys were stored.

--- a/apps/desktop/src/main/ipc/routers/account.ts
+++ b/apps/desktop/src/main/ipc/routers/account.ts
@@ -1107,7 +1107,18 @@ export const accountRouter = router({
     .input(z.object({ chatType: z.number().int(), uid: z.string().min(1) }))
     .query(async ({ input }) => {
       const result = await requireServices().unreadInfo.getUnreadInfo(input.chatType, input.uid);
-      return result ? { msgSeq: result.msgSeq?.toString() } : null;
+      if (!result) return null;
+      return {
+        msgSeq: result.msgSeq?.toString(),
+        // 特别关心标记（若该会话有特别关心未读）。seq 保留供上层使用。
+        specialCare: result.specialCare
+          ? {
+              msgSeq: result.specialCare.msgSeq.toString(),
+              senderUid: result.specialCare.senderUid,
+              sendTime: result.specialCare.sendTime.toString(),
+            }
+          : undefined,
+      };
     }),
 
   /** Newest page of a conversation (open / switch-into), newest-first. */

--- a/apps/desktop/src/main/ipc/routers/account.ts
+++ b/apps/desktop/src/main/ipc/routers/account.ts
@@ -42,6 +42,8 @@ import {
   type AlbumMedia,
   type NewMessages,
   type DbChange,
+  type RenderC2cMsg,
+  type RenderGroupMsg,
 } from '@weq/service';
 import {
   buddyRequestToWire,
@@ -1588,6 +1590,42 @@ export const accountRouter = router({
       // Reverse the editable wire form: `{ type:'Buffer', data }` → Uint8Array.
       const elements = elementsFromEditable(input.elements);
       return requireServices().msgs.updateElements(BigInt(input.msgId), elements);
+    }),
+
+  /** Reversible soft-delete of one message (hidden from its conversation). */
+  deleteMessage: procedure
+    .input(z.object({ msgId: z.string().min(1) }))
+    .mutation(async ({ input }) => {
+      return requireServices().msgs.deleteMessage(BigInt(input.msgId));
+    }),
+
+  /** Restore a soft-deleted message. No-op if it was never soft-deleted. */
+  restoreMessage: procedure
+    .input(z.object({ msgId: z.string().min(1) }))
+    .mutation(async ({ input }) => {
+      return requireServices().msgs.restoreMessage(BigInt(input.msgId));
+    }),
+
+  /** Hard-delete (irreversible): physically drop the message row by msgId. */
+  hardDeleteMessage: procedure
+    .input(z.object({ msgId: z.string().min(1) }))
+    .mutation(async ({ input }) => {
+      return requireServices().msgs.hardDeleteMessage(BigInt(input.msgId));
+    }),
+
+  /**
+   * List the soft-deleted (hidden, restorable) messages of one conversation,
+   * newest-first, serialized like any other message page so the renderer can
+   * reuse its chat bubbles in the "查看删除消息" panel.
+   */
+  deletedMessages: procedure
+    .input(z.object({ kind: z.enum(['c2c', 'group']), conv: z.string().min(1) }))
+    .query(async ({ input }): Promise<ChatMsgWire[]> => {
+      const msgs = requireServices().msgs;
+      const rows = await msgs.getDeletedMessages(input.kind, input.conv);
+      return input.kind === 'group'
+        ? (rows as RenderGroupMsg[]).map(groupMsgToWire)
+        : (rows as RenderC2cMsg[]).map(c2cMsgToWire);
     }),
 
   /**

--- a/apps/desktop/src/main/ipc/routers/avatar_resource.ts
+++ b/apps/desktop/src/main/ipc/routers/avatar_resource.ts
@@ -42,4 +42,16 @@ export const avatarResourceRouter = router({
         cursor: input.cursor ?? null,
       });
     }),
+
+  /**
+   * Given a QQ number, derive where its avatar is cached (the 头像路径 tool).
+   * `kind=user` translates uin→uid via profile_info_v6; `kind=group` uses the
+   * number directly (group uin == uid). Returns the uid, computed hash and each
+   * variant's on-disk presence.
+   */
+  computePath: procedure
+    .input(z.object({ kind: z.enum(['user', 'group']), qq: z.string().trim() }))
+    .query(({ input }) => {
+      return requireServices().avatarResource.probeByQq(input.kind, input.qq);
+    }),
 });

--- a/apps/desktop/src/main/ipc/routers/bootstrap.ts
+++ b/apps/desktop/src/main/ipc/routers/bootstrap.ts
@@ -598,6 +598,22 @@ export const bootstrapRouter = router({
     return boot.userConfig.getCacheDirInfo();
   }),
 
+  /**
+   * Per-category size of the clearable WeQ caches (头像/媒体/商城表情/语音).
+   * Only these re-downloadable/re-generatable categories are listed —
+   * agentlab / weq-assistant / export are user content and stay untouched.
+   */
+  listClearableCache: procedure.query(() => {
+    return requireBootstrap().userConfig.listClearableCache();
+  }),
+
+  /** Delete the given clearable cache categories (all when omitted). */
+  clearWeqCache: procedure
+    .input(z.object({ ids: z.array(z.string()).optional() }).optional())
+    .mutation(({ input }) => {
+      return requireBootstrap().userConfig.clearCache(input?.ids);
+    }),
+
   // ---- filesystem dialog (Tencent Files fallback / manual db pick) ----
 
   pickTencentFilesRoot: procedure.mutation(async (): Promise<PickRootResult> => {

--- a/apps/desktop/src/main/ipc/routers/resource_cleanup.ts
+++ b/apps/desktop/src/main/ipc/routers/resource_cleanup.ts
@@ -1,0 +1,47 @@
+/**
+ * `account.resourceCleanup.*` — the 本地资源整理 → 清理释放 backend.
+ *
+ * Thin tRPC skin over `ResourceCleanupService` (see `@weq/service`): list the
+ * deletable nt_data resource trees with their on-disk sizes, and execute a batch
+ * of cleanup instructions. All whitelist / containment safety lives in the
+ * service — this layer only shapes input. Destructive; account-bound.
+ */
+
+import { z } from 'zod';
+import { getAppContext, type AccountServices } from '../../context/app_context';
+import { procedure, router } from '../trpc';
+
+function requireServices(): AccountServices {
+  const ctx = getAppContext();
+  if (!ctx.services) {
+    throw new Error('No account session open — call bootstrap.openAccount first.');
+  }
+  return ctx.services;
+}
+
+export const resourceCleanupRouter = router({
+  /** Per-target on-disk size (files/bytes + ori/thumb split). Slow — stats every file. */
+  listTargets: procedure.query(() => {
+    return requireServices().resourceCleanup.listTargets();
+  }),
+
+  /**
+   * Delete the given targets. `variant`: 'all' wipes the whole tree, 'ori'/'thumb'
+   * only removes original / preview files (ignored for non-split targets). Unknown
+   * ids are silently dropped by the service's whitelist.
+   */
+  cleanup: procedure
+    .input(
+      z.object({
+        instructions: z.array(
+          z.object({
+            id: z.string().min(1),
+            variant: z.enum(['all', 'ori', 'thumb']),
+          }),
+        ),
+      }),
+    )
+    .mutation(({ input }) => {
+      return requireServices().resourceCleanup.cleanup(input.instructions);
+    }),
+});

--- a/apps/desktop/src/main/ipc/serde.ts
+++ b/apps/desktop/src/main/ipc/serde.ts
@@ -225,6 +225,8 @@ export interface RecentContactWire {
   /** Local absolute path to the avatar file (unused by the renderer for now). */
   targetAvatar: string;
   targetRemark: string;
+  /** 41220 — message-notify level. 1 = notify normally; else (observed 4) 免打扰/muted. */
+  notifyLevel: number;
 }
 
 export function c2cMsgToWire(m: RenderC2cMsg): ChatMsgWire {
@@ -269,6 +271,7 @@ export function recentContactToWire(c: RecentContact): RecentContactWire {
     senderRemark: c.senderRemark,
     targetAvatar: c.targetAvatar,
     targetRemark: c.targetRemark,
+    notifyLevel: c.notifyLevel,
   };
 }
 

--- a/apps/desktop/src/main/media_protocol.ts
+++ b/apps/desktop/src/main/media_protocol.ts
@@ -14,6 +14,8 @@
  *   weq-media://mface?pack=<emojiPackId>&hash=<previewMd5Hex> → sticker bytes
  *   weq-media://agentvoice?persona=&id=<hash.ext>             → clone TTS audio bytes
  *   weq-media://avatar?scope=user&hash=<hash>&v=big|small     → local avatar-cache bytes
+ *   weq-media://avatar?scope=user&uin=<qq>&fb=<cdnUrl>        → local by uid-hash, CDN fallback
+ *   weq-media://avatar?scope=group&uid=<code>&fb=<cdnUrl>     → group avatar (uin==uid)
  *   weq-media://localfile?path=<absOriPath>                   → File/Ori file bytes (image preview)
  *   weq-media://localmedia?kind=pic&rel=<month/Ori/name>      → PhotoWall/Qzone/Pic/Video cache bytes
  *   weq-media://localvoice?rel=<month/Ori/name>               → decoded WAV for a Ptt cache clip
@@ -94,6 +96,27 @@ function notFound(reason: string): Response {
 
 function fileResponse(path: string): Promise<Response> {
   return net.fetch(pathToFileURL(path).toString());
+}
+
+/**
+ * CDN fallback for an avatar the local cache didn't have. Routes through the
+ * shared {@link AvatarCacheService} disk cache (so the fetched bytes warm the
+ * same cache the rest of the app reads), returning 404 on any failure so the
+ * renderer shows its glyph.
+ */
+async function avatarFallbackResponse(src: string): Promise<Response> {
+  if (!/^https?:\/\//i.test(src)) return notFound('avatar fallback needs http url');
+  const cache = getAppContext().bootstrap?.avatarCache;
+  if (!cache) return notFound('avatar cache unavailable');
+  try {
+    const blob = await cache.get(src);
+    return new Response(new Uint8Array(blob.data), {
+      status: 200,
+      headers: { 'Content-Type': blob.contentType, 'Cache-Control': 'public, max-age=86400' },
+    });
+  } catch {
+    return notFound('avatar fallback failed');
+  }
 }
 
 async function albumRemoteResponse(src: string): Promise<Response> {
@@ -225,18 +248,31 @@ export function registerMediaProtocol(): void {
           return path ? fileResponse(path) : notFound('agentvoice not found');
         }
         case 'avatar': {
-          // Local avatar cache (nt_data/avatar/{user,group,cover}). The renderer
-          // asks for the big original first and falls back to the small thumb via
-          // <img onError>. scope+hash+v identify the file; bytes stream off disk.
+          // Local avatar cache (nt_data/avatar/{user,group,cover}). Three ways in:
+          //   hash=<hash>    — an explicit file (本地资源 → 头像 browser)
+          //   uid=<peer uid> — compute the file hash from the uid formula
+          //   uin=<peer qq>  — same, translating uin→uid (group uin == uid)
+          // `v=big|small` picks the resolution (the other is tried as backup).
+          // `fb=<enc cdn url>` is the guaranteed fallback: on a local miss we
+          // serve (and disk-cache) the CDN avatar, so the renderer needs only one
+          // <img src> and its onError is the final glyph net.
           const scope = q.get('scope') ?? '';
           const hash = q.get('hash') ?? '';
+          const uid = q.get('uid') ?? '';
+          const uin = q.get('uin') ?? '';
           const variant = q.get('v') === 'small' ? 'small' : 'big';
+          const fb = q.get('fb') ?? '';
           if (scope !== 'user' && scope !== 'group' && scope !== 'cover') {
             return notFound('avatar needs scope=user|group|cover');
           }
-          if (!hash) return notFound('avatar needs hash');
-          const path = await services.avatarResource.resolveFile(scope, hash, variant);
-          return path ? fileResponse(path) : notFound('avatar not found');
+          let path: string | null = null;
+          if (hash) path = await services.avatarResource.resolveFile(scope, hash, variant);
+          else if (uid) path = await services.avatarResource.resolveByUid(scope, uid, variant);
+          else if (uin) path = await services.avatarResource.resolveByUin(scope, uin, variant);
+          if (path) return fileResponse(path);
+          // Local miss → CDN fallback (disk-cached by AvatarCacheService).
+          if (fb) return avatarFallbackResponse(fb);
+          return notFound('avatar not found');
         }
         case 'cemoji': {
           // Custom-emoji cache (nt_data/Emoji/emoji-recv/<month> + personal_emoji).

--- a/apps/desktop/src/main/voice.ts
+++ b/apps/desktop/src/main/voice.ts
@@ -2,10 +2,14 @@
  * SILK voice decode for the media protocol.
  *
  * QQ stores PTT as Tencent SILK v3 (`.amr` extension, header `#!SILK_V3`,
- * sometimes with a 1-byte prefix — `silk-wasm` handles both). No browser plays
- * SILK, so we decode to 24 kHz mono PCM via `silk-wasm` and wrap it in a WAV
- * container. Results cache under `appData/cache/voice/<name>.wav`, so a clip
- * decodes once and replays off disk.
+ * preceded by a 1-byte flag). No browser plays SILK, so we decode to 24 kHz
+ * mono PCM via `silk-wasm` and wrap it in a WAV container. Results cache under
+ * `appData/cache/voice/<name>.wav`, so a clip decodes once and replays off disk.
+ *
+ * silk-wasm's wasm decoder only accepts `0x02` as that flag byte, but QQ also
+ * emits clips with a `0x03` flag (both are valid Tencent SILK, they just decode
+ * fine once normalized). `normalizeSilk` rewrites whatever precedes the magic
+ * to a single `0x02`, so every variant reaches the decoder in the shape it wants.
  *
  * silk-wasm lives in this app's dependencies (not @weq/service) because the
  * wasm runtime belongs in the Electron main process.
@@ -21,6 +25,22 @@ const TRANSCRIBE_SAMPLE_RATE = 16000;
 const CHANNELS = 1;
 const BITS_PER_SAMPLE = 16;
 
+const SILK_MAGIC = Buffer.from('#!SILK_V3');
+const SILK_FLAG = 0x02;
+
+/**
+ * Normalize a Tencent SILK buffer so silk-wasm accepts it: the wasm decoder
+ * only recognizes a `0x02` flag byte before the `#!SILK_V3` magic, but QQ also
+ * ships clips flagged `0x03` (and potentially other bytes). Rewrite whatever
+ * precedes the magic to exactly one `0x02`. If the magic isn't present, hand the
+ * buffer back untouched and let the decoder fail as it would have.
+ */
+function normalizeSilk(silk: Buffer): Buffer {
+  const idx = silk.indexOf(SILK_MAGIC);
+  if (idx < 0) return silk;
+  return Buffer.concat([Buffer.from([SILK_FLAG]), silk.subarray(idx)]);
+}
+
 /**
  * Decode the SILK file at `silkPath` to a cached WAV; returns the WAV path, or
  * null if the source is missing or decoding fails.
@@ -33,7 +53,7 @@ export async function decodeSilkToWav(silkPath: string): Promise<string | null> 
   if (existsSync(cachePath)) return cachePath;
 
   try {
-    const silk = readFileSync(silkPath);
+    const silk = normalizeSilk(readFileSync(silkPath));
     const { data: pcm } = await decode(silk, SAMPLE_RATE);
     mkdirSync(cacheDir, { recursive: true });
     writeFileSync(cachePath, wrapWav(pcm));
@@ -52,7 +72,7 @@ export async function decodeSilkToWav(silkPath: string): Promise<string | null> 
 export async function decodeSilkToFile(silkPath: string, destPath: string): Promise<boolean> {
   if (!silkPath || !existsSync(silkPath)) return false;
   try {
-    const silk = readFileSync(silkPath);
+    const silk = normalizeSilk(readFileSync(silkPath));
     const { data: pcm } = await decode(silk, SAMPLE_RATE);
     mkdirSync(dirname(destPath), { recursive: true });
     writeFileSync(destPath, wrapWav(pcm));
@@ -72,7 +92,7 @@ export async function decodeSilkToFile(silkPath: string, destPath: string): Prom
 export async function decodeSilkToWav16kBuffer(silkPath: string): Promise<Buffer | null> {
   if (!silkPath || !existsSync(silkPath)) return null;
   try {
-    const silk = readFileSync(silkPath);
+    const silk = normalizeSilk(readFileSync(silkPath));
     const { data: pcm } = await decode(silk, TRANSCRIBE_SAMPLE_RATE);
     return wrapWav(pcm, TRANSCRIBE_SAMPLE_RATE);
   } catch (e) {

--- a/apps/desktop/src/renderer/src/components/GroupAnalyticsDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/GroupAnalyticsDialog.tsx
@@ -120,9 +120,24 @@ export function GroupAnalyticsDialog({
   const loadMembers = useCallback(async () => {
     setMembersLoading(true);
     setMembersError(null);
+    setMembers([]);
     try {
-      const result = await client.account.listGroupMembers.query({ groupCode, limit: 300 });
-      setMembers(result as MemberWire[]);
+      // 全量分页加载：后端单页上限 300，这里循环翻页累加，最多 3000 个，
+      // 保证搜索能命中所有成员（而不是只搜到前一页）。边加载边填充，
+      // 用户不必等全部拉完就能看到并搜索已加载的成员。
+      const PAGE_SIZE = 300;
+      const MAX_MEMBERS = 3000;
+      const all: MemberWire[] = [];
+      for (let offset = 0; offset < MAX_MEMBERS; offset += PAGE_SIZE) {
+        const page = (await client.account.listGroupMembers.query({
+          groupCode,
+          limit: PAGE_SIZE,
+          offset,
+        })) as MemberWire[];
+        all.push(...page);
+        setMembers([...all]);
+        if (page.length < PAGE_SIZE) break; // 最后一页，已取完
+      }
     } catch (e) {
       setMembersError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -334,14 +349,16 @@ export function GroupAnalyticsDialog({
                   onChange={(e) => setMemberSearch(e.target.value)}
                 />
               </div>
-              {membersLoading ? (
+              {membersLoading && members.length === 0 ? (
                 <div className="ga-loading">
                   <Loader2 size={28} className="weq-spin" />
                 </div>
               ) : membersError ? (
                 <div className="ga-error">{membersError}</div>
               ) : filteredMembers.length === 0 ? (
-                <p className="ga-placeholder">没有匹配的成员</p>
+                <p className="ga-placeholder">
+                  {membersLoading ? "加载中…" : "没有匹配的成员"}
+                </p>
               ) : (
                 <div className="ga-members-grid">
                   {filteredMembers.map((m) => (
@@ -363,6 +380,12 @@ export function GroupAnalyticsDialog({
                       {m.memberLevel > 0 && <span className="ga-member-level">LV{m.memberLevel}</span>}
                     </button>
                   ))}
+                </div>
+              )}
+              {membersLoading && members.length > 0 && (
+                <div className="ga-members-loading-more">
+                  <Loader2 size={14} className="weq-spin" />
+                  <span>正在加载全部成员…（已 {members.length}）</span>
                 </div>
               )}
             </div>

--- a/apps/desktop/src/renderer/src/components/ImageLightbox.tsx
+++ b/apps/desktop/src/renderer/src/components/ImageLightbox.tsx
@@ -7,13 +7,15 @@
  *   - <ImageLightbox/>         mount once near the root; renders the overlay
  *     for whatever the store currently holds (a single global portal).
  *
- * Click the backdrop or press ESC to close.
+ * Click the backdrop or press ESC to close. Scroll to zoom (anchored at the
+ * cursor), click the image to toggle 2× zoom, drag to pan when zoomed.
  */
 
 import { useEffect, type ReactElement } from 'react';
 import { createPortal } from 'react-dom';
 import { create } from 'zustand';
 import { X } from 'lucide-react';
+import { useZoomPan } from './useZoomPan';
 
 interface LightboxStore {
   src: string | null;
@@ -44,6 +46,7 @@ export function ImageLightbox(): ReactElement | null {
   const src = useLightbox((s) => s.src);
   const alt = useLightbox((s) => s.alt);
   const close = useLightbox((s) => s.close);
+  const zoom = useZoomPan(src);
 
   useEffect(() => {
     if (!src) return;
@@ -61,13 +64,17 @@ export function ImageLightbox(): ReactElement | null {
       <button className="weq-lightbox-close" type="button" onClick={close} aria-label="关闭">
         <X size={22} />
       </button>
-      <img
-        className="weq-lightbox-image weq-anim-pop"
-        src={src}
-        alt={alt}
-        draggable={false}
-        onMouseDown={(event) => event.stopPropagation()}
-      />
+      <div className="weq-lightbox-stage weq-anim-pop" onMouseDown={(event) => event.stopPropagation()}>
+        <img
+          ref={zoom.setEl}
+          className="weq-lightbox-image"
+          src={src}
+          alt={alt}
+          draggable={false}
+          style={zoom.style}
+          onMouseDown={zoom.onMouseDown}
+        />
+      </div>
     </div>,
     document.body,
   );

--- a/apps/desktop/src/renderer/src/components/MemberProfileCard.tsx
+++ b/apps/desktop/src/renderer/src/components/MemberProfileCard.tsx
@@ -1,0 +1,245 @@
+// @ts-nocheck
+/**
+ * 群成员资料卡片（贴光标弹出的 anchored popover）。
+ *
+ * 点击群成员列表某一行时，在鼠标点击处弹出。基础信息（头像 / 群名片 / 角色 /
+ * 头衔 / 等级 / 入群时间）直接取自已在手的 GroupMember，QQ 号 / 昵称 / 性别 /
+ * 年龄 / 生日 / 签名 / 亲密度等「陌生人资料」字段异步走 account.getProfile(uid)
+ * 从 profile_info_v6 补全。视觉沿用好友资料灯箱（weq-profile-*）的设计语言，
+ * 只是把居中灯箱换成贴光标的浮层。
+ */
+import {
+	Award,
+	BadgeCheck,
+	Cake,
+	CalendarDays,
+	Check,
+	Clock,
+	Copy,
+	Crown,
+	Fingerprint,
+	Hash,
+	Heart,
+	Loader2,
+	Shield,
+	Sparkles,
+	User as UserIcon,
+	X,
+} from "lucide-react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { client } from "../trpc/client";
+import { Avatar } from "../im-template/template/primitives";
+import { cn } from "../im-template/template/classNames";
+import { copyTextToClipboard } from "../im-template/template/clipboard";
+import { displayUserName } from "../im-template/template/user";
+import { useEscapeToClose } from "../im-template/template/modalUtils";
+import {
+	ProfileRow,
+	birthdayText,
+	constellationOf,
+	genderLabel,
+} from "../im-template/template/profilePanes";
+
+/** ISO 字符串 → zh-CN 年月日；无效 / 空 / epoch 返回 null。 */
+function shortDate(value) {
+	if (!value) return null;
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime()) || date.getFullYear() <= 2000) return null;
+	return new Intl.DateTimeFormat("zh-CN", {
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).format(date);
+}
+
+const ROLE_META = {
+	owner: { label: "群主", Icon: Crown, cls: "is-owner" },
+	admin: { label: "管理员", Icon: Shield, cls: "is-admin" },
+};
+
+export function MemberProfileCard({ member, anchor, onClose }) {
+	const [profile, setProfile] = useState(null);
+	const [loading, setLoading] = useState(true);
+	const [copied, setCopied] = useState(false);
+	const cardRef = useRef(null);
+	const [pos, setPos] = useState({ left: anchor.x + 14, top: anchor.y + 8, ready: false });
+
+	const uid = member.identityValue;
+
+	useEscapeToClose(onClose);
+
+	// 补全陌生人资料字段。
+	useEffect(() => {
+		let alive = true;
+		setLoading(true);
+		setProfile(null);
+		client.account.getProfile
+			.query({ uid })
+			.then((p) => {
+				if (alive) {
+					setProfile(p);
+					setLoading(false);
+				}
+			})
+			.catch(() => {
+				if (alive) setLoading(false);
+			});
+		return () => {
+			alive = false;
+		};
+	}, [uid]);
+
+	// 测量真实尺寸后把卡片夹在视口内：默认落在光标右下，右 / 下溢出则翻向左 / 上。
+	useLayoutEffect(() => {
+		const el = cardRef.current;
+		if (!el) return;
+		const w = el.offsetWidth;
+		const h = el.offsetHeight;
+		const vw = window.innerWidth;
+		const vh = window.innerHeight;
+		const M = 10;
+		let left = anchor.x + 14;
+		let top = anchor.y + 8;
+		if (left + w > vw - M) left = anchor.x - w - 14;
+		if (left < M) left = M;
+		if (top + h > vh - M) top = vh - h - M;
+		if (top < M) top = M;
+		setPos({ left, top, ready: true });
+	}, [anchor.x, anchor.y, loading, profile]);
+
+	const name = displayUserName(member);
+	const role = ROLE_META[member.role];
+	const uin = profile?.uin && profile.uin !== "0" ? profile.uin : null;
+	const nickDiffers = profile?.nick && profile.nick !== name && profile.nick !== member.remark;
+	const gender = genderLabel(profile?.gender);
+	const genderAge = [gender, profile?.age ? `${profile.age} 岁` : null].filter(Boolean).join(" · ");
+	const zodiac = profile ? constellationOf(profile.birthMonth, profile.birthDay) : null;
+	const birthday = profile ? birthdayText(profile.birthYear, profile.birthMonth, profile.birthDay) : null;
+	const intimacy =
+		profile?.intimacy && Number(profile.intimacy) > 0
+			? Number(profile.intimacy).toLocaleString("en-US")
+			: null;
+	const levelText = member.levelName || (member.memberLevel ? `Lv.${member.memberLevel}` : null);
+	const joinedAt = shortDate(member.joinedAt);
+	const lastSpeak = shortDate(member.lastSpeakAt);
+
+	async function copyUin() {
+		if (!uin) return;
+		const ok = await copyTextToClipboard(uin);
+		if (ok) {
+			setCopied(true);
+			window.setTimeout(() => setCopied(false), 1500);
+		}
+	}
+
+	return createPortal(
+		<div
+			className="weq-member-pop-scrim"
+			role="presentation"
+			style={{ position: "fixed", inset: 0, zIndex: 90 }}
+			onMouseDown={onClose}
+		>
+			<section
+				ref={cardRef}
+				className="weq-member-pop weq-anim-pop"
+				style={{
+					position: "fixed",
+					left: pos.left,
+					top: pos.top,
+					opacity: pos.ready ? 1 : 0,
+				}}
+				role="dialog"
+				aria-modal="true"
+				aria-label="群成员资料"
+				onMouseDown={(event) => event.stopPropagation()}
+			>
+				<button
+					className="weq-profile-close"
+					type="button"
+					title="关闭"
+					aria-label="关闭"
+					onClick={onClose}
+				>
+					<X size={15} />
+				</button>
+
+				<div className="weq-profile-hero">
+					<span className="weq-profile-avatar">
+						<Avatar name={name} avatarUrl={member.avatarUrl} seed={uid} />
+					</span>
+					<strong className="weq-profile-name">{name}</strong>
+					{nickDiffers ? <span className="weq-profile-nick">昵称 {profile.nick}</span> : null}
+
+					{uin ? (
+						<button className="weq-profile-id" type="button" onClick={copyUin} title="点击复制">
+							<span>QQ</span>
+							<span className="weq-number">{uin}</span>
+							{copied ? <Check size={12} /> : <Copy size={12} />}
+						</button>
+					) : null}
+
+					{role || genderAge || zodiac ? (
+						<div className="weq-profile-chips">
+							{role ? (
+								<span className={cn("weq-profile-rel", role.cls)}>
+									<role.Icon size={13} strokeWidth={2.2} />
+									{role.label}
+								</span>
+							) : null}
+							{genderAge ? <span className="weq-profile-chip">{genderAge}</span> : null}
+							{zodiac ? (
+								<span className="weq-profile-chip">
+									<Sparkles size={12} />
+									{zodiac}
+								</span>
+							) : null}
+						</div>
+					) : null}
+
+					{member.customTitle ? (
+						<div className="weq-profile-chips">
+							<span className="weq-member-title">
+								<BadgeCheck size={12} />
+								{member.customTitle}
+							</span>
+						</div>
+					) : null}
+
+					{profile?.signature ? <p className="weq-profile-sign">{profile.signature}</p> : null}
+				</div>
+
+				<div className="weq-profile-list">
+					{levelText ? (
+						<ProfileRow icon={<Award size={13} />} label="群等级" value={levelText} />
+					) : null}
+					{birthday ? <ProfileRow icon={<Cake size={13} />} label="生日" value={birthday} /> : null}
+					{intimacy ? (
+						<ProfileRow icon={<Heart size={13} />} label="亲密度" value={intimacy} mono accent />
+					) : null}
+					{joinedAt ? (
+						<ProfileRow icon={<CalendarDays size={13} />} label="入群时间" value={joinedAt} />
+					) : null}
+					{lastSpeak ? (
+						<ProfileRow icon={<Clock size={13} />} label="最后发言" value={lastSpeak} />
+					) : null}
+					{profile?.remark ? (
+						<ProfileRow icon={<UserIcon size={13} />} label="备注" value={profile.remark} />
+					) : null}
+					{profile?.qid ? (
+						<ProfileRow icon={<Fingerprint size={13} />} label="QID" value={profile.qid} mono />
+					) : null}
+					<ProfileRow icon={<Hash size={13} />} label="UID" value={uid} mono />
+				</div>
+
+				{loading ? (
+					<div className="weq-member-loading">
+						<Loader2 size={14} />
+						<span>加载资料…</span>
+					</div>
+				) : null}
+			</section>
+		</div>,
+		document.body,
+	);
+}

--- a/apps/desktop/src/renderer/src/components/MemberProfileCard.tsx
+++ b/apps/desktop/src/renderer/src/components/MemberProfileCard.tsx
@@ -65,7 +65,9 @@ export function MemberProfileCard({ member, anchor, onClose }) {
 	const cardRef = useRef(null);
 	const [pos, setPos] = useState({ left: anchor.x + 14, top: anchor.y + 8, ready: false });
 
-	const uid = member.identityValue;
+	// 真正的 uid 在 member.id；member.identityValue 展示用的是 uin（QQ号）。
+	// getProfile 需要 uid，早先误传 identityValue(=uin) 会拉不到 profile_info_v6。
+	const uid = member.id;
 
 	useEscapeToClose(onClose);
 
@@ -120,7 +122,16 @@ export function MemberProfileCard({ member, anchor, onClose }) {
 		profile?.intimacy && Number(profile.intimacy) > 0
 			? Number(profile.intimacy).toLocaleString("en-US")
 			: null;
-	const levelText = member.levelName || (member.memberLevel ? `Lv.${member.memberLevel}` : null);
+	// 群等级 = 数字等级（memberLevel）；levelName 是群主给各等级段起的段位名称
+	// （元老 / 潜水 …），是「头衔样式」的字符串，只作为副标题附在数字后面，
+	// 不能单独当等级展示——否则看起来就成了群头衔。
+	const levelText = member.memberLevel
+		? `Lv.${member.memberLevel}${
+				member.levelName && member.levelName !== `Lv${member.memberLevel}`
+					? ` · ${member.levelName}`
+					: ""
+			}`
+		: member.levelName || null;
 	const joinedAt = shortDate(member.joinedAt);
 	const lastSpeak = shortDate(member.lastSpeakAt);
 

--- a/apps/desktop/src/renderer/src/components/QqArk.tsx
+++ b/apps/desktop/src/renderer/src/components/QqArk.tsx
@@ -28,7 +28,7 @@
  */
 
 import { useMemo, type ReactElement } from 'react';
-import { MapPin } from 'lucide-react';
+import { MapPin, Megaphone } from 'lucide-react';
 import { cachedAvatarUrl } from '../lib/avatarCache';
 
 // ---- types ---------------------------------------------------------------
@@ -61,6 +61,16 @@ function s(p: ArkPayload, key: string): string {
   return typeof v === 'string' ? v : '';
 }
 
+/** Decode a base64 string as UTF-8 (atob yields Latin-1 bytes → TextDecoder). */
+function decodeBase64Utf8(raw: string): string {
+  try {
+    const bytes = Uint8Array.from(atob(raw), (c) => c.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return raw;
+  }
+}
+
 // ---- the universal card --------------------------------------------------
 
 export function QqArk({ arkData }: { arkData: unknown }): ReactElement | null {
@@ -70,6 +80,13 @@ export function QqArk({ arkData }: { arkData: unknown }): ReactElement | null {
   const firstKey = data?.meta ? Object.keys(data.meta)[0] : undefined;
   const p: ArkPayload | null = data?.meta && firstKey ? data.meta[firstKey] ?? null : null;
   if (!data || !p) return null;
+
+  // 群公告 (com.tencent.mannounce) 不走通用引擎：它的 title/text 是 base64
+  // (encode=1)，且正文藏在 text 字段、没有任何图片素材，通用引擎会把原始
+  // base64 当标题直接吐出来。单独渲染成公告卡。
+  if (data.app === 'com.tencent.mannounce') {
+    return <ArkGroupAnnounce p={p} />;
+  }
 
   const prompt = typeof data.prompt === 'string' ? data.prompt : '';
 
@@ -190,6 +207,37 @@ export function QqArk({ arkData }: { arkData: unknown }): ReactElement | null {
           <img className="weq-ark-footer-icon" src={cachedAvatarUrl(footerIcon) ?? footerIcon} alt="" loading="lazy" />
         ) : null}
         <span>{footerLabel}</span>
+      </div>
+    </div>
+  );
+}
+
+// ---- the group announcement card (com.tencent.mannounce) -----------------
+
+/**
+ * 群公告卡片。payload 里 title/text 为 base64 (encode=1)，无任何图片素材，
+ * 所以不复用通用引擎：解码后渲染「群公告」头 + 标题 + 正文。正文保留换行
+ * (white-space: pre-wrap)，因为公告常带多行段落。卡片不可点击（payload 只
+ * 有 fid/gc/sign，没有可跳转的 http 链接）。
+ */
+function ArkGroupAnnounce({ p }: { p: ArkPayload }): ReactElement {
+  const encoded = p.encode === 1 || p.encode === '1';
+  const decode = (raw: string): string => (encoded ? decodeBase64Utf8(raw) : raw);
+  const title = decode(s(p, 'title')).trim();
+  const text = decode(s(p, 'text')).trim();
+
+  return (
+    <div className="weq-ark-container weq-ark-announce">
+      <div className="weq-ark-content">
+        <div className="weq-ark-header">
+          <Megaphone className="weq-ark-announce-icon" size={14} strokeWidth={2.2} />
+          <span>群公告</span>
+        </div>
+        {title ? <div className="weq-ark-title">{title}</div> : null}
+        {text ? <div className="weq-ark-announce-text">{text}</div> : null}
+      </div>
+      <div className="weq-ark-footer">
+        <span>群公告</span>
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/components/QqArk.tsx
+++ b/apps/desktop/src/renderer/src/components/QqArk.tsx
@@ -216,14 +216,14 @@ export function QqArk({ arkData }: { arkData: unknown }): ReactElement | null {
 
 /**
  * 群公告卡片。payload 里 title/text 为 base64 (encode=1)，无任何图片素材，
- * 所以不复用通用引擎：解码后渲染「群公告」头 + 标题 + 正文。正文保留换行
- * (white-space: pre-wrap)，因为公告常带多行段落。卡片不可点击（payload 只
- * 有 fid/gc/sign，没有可跳转的 http 链接）。
+ * 所以不复用通用引擎。title 实为卡片头部标签（如「群公告」），text 才是正文；
+ * 正文保留换行 (white-space: pre-wrap)，因为公告常带多行段落。卡片不可点击
+ * （payload 只有 fid/gc/sign，没有可跳转的 http 链接）。
  */
 function ArkGroupAnnounce({ p }: { p: ArkPayload }): ReactElement {
   const encoded = p.encode === 1 || p.encode === '1';
   const decode = (raw: string): string => (encoded ? decodeBase64Utf8(raw) : raw);
-  const title = decode(s(p, 'title')).trim();
+  const title = decode(s(p, 'title')).trim() || '群公告';
   const text = decode(s(p, 'text')).trim();
 
   return (
@@ -231,13 +231,9 @@ function ArkGroupAnnounce({ p }: { p: ArkPayload }): ReactElement {
       <div className="weq-ark-content">
         <div className="weq-ark-header">
           <Megaphone className="weq-ark-announce-icon" size={14} strokeWidth={2.2} />
-          <span>群公告</span>
+          <span>{title}</span>
         </div>
-        {title ? <div className="weq-ark-title">{title}</div> : null}
         {text ? <div className="weq-ark-announce-text">{text}</div> : null}
-      </div>
-      <div className="weq-ark-footer">
-        <span>群公告</span>
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/src/components/QqMedia.tsx
+++ b/apps/desktop/src/renderer/src/components/QqMedia.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useEffect, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react';
-import { Cloud, FileText, Loader2 } from 'lucide-react';
+import { Cloud, FileText, Loader2, Sparkles, Star } from 'lucide-react';
 import { fileIconUrl, mediaUrl } from '@renderer/lib/resourceUrl';
 import { cn } from '@renderer/lib/utils';
 import { trpc } from '@renderer/trpc/client';
@@ -353,8 +353,13 @@ export function QqVoice({ data, sendTimeMs }: { data: Data; sendTimeMs: number }
   const name = str(data, 'fileName');
   const token = str(data, 'fileToken');
   const waveform = Array.isArray(data.waveform) ? (data.waveform as number[]) : [];
-  // waveform is one byte per 0.1s; length/10 = duration in seconds.
-  const seconds = waveform.length > 0 ? Math.max(1, Math.round(waveform.length / 10)) : 0;
+  // Duration comes from the element (wire tag 45906), NOT the waveform: AI 声聊
+  // clips carry a fixed 30-byte synthetic strip, so waveform.length/10 is wrong
+  // for them. Fall back to the waveform only when duration is absent (0).
+  const seconds =
+    num(data, 'pttDuration') || (waveform.length > 0 ? Math.max(1, Math.round(waveform.length / 10)) : 0);
+  const voiceChanged = Boolean(data.voiceChanged);
+  const isAiVoice = Boolean(data.isAiVoice);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [playing, setPlaying] = useState(false);
 
@@ -410,17 +415,33 @@ export function QqVoice({ data, sendTimeMs }: { data: Data; sendTimeMs: number }
       .catch((err) => setTranscribeError(err instanceof Error ? err.message : String(err)));
   };
 
-  // Downsample the envelope to a fixed bar count for a stable QQ-style strip.
-  const bars = sampleBars(waveform, 28);
+  // Bar count tracks duration (QQ-style: longer clip → longer strip), with a
+  // floor so short clips — notably AI 声聊, which are often 1–5s — always show a
+  // visible waveform, and a cap so very long clips stay within the bubble.
+  const barCount = Math.max(12, Math.min(36, 8 + Math.round(seconds)));
+  const bars = sampleBars(waveform, barCount);
   const hasResult = transcript !== null || transcribeError !== null;
 
   return (
     <div className="qq-voice-wrap">
       <div className="qq-voice-row">
-        <div className={cn('qq-media-voice', playing && 'is-playing')} role="button" onClick={toggle}>
+        <div
+          className={cn('qq-media-voice', playing && 'is-playing')}
+          role="button"
+          onClick={toggle}
+        >
           <span className="qq-media-voice-play" aria-hidden>
             {playing ? '❚❚' : '▶'}
           </span>
+          {isAiVoice ? (
+            <span className="qq-media-voice-ai" title="AI 声聊">
+              <Sparkles size={11} strokeWidth={2} aria-hidden />
+              AI
+            </span>
+          ) : null}
+          {voiceChanged ? (
+            <Star size={13} strokeWidth={2} className="qq-media-voice-changed" aria-label="变声语音" />
+          ) : null}
           <span className="qq-media-voice-wave" aria-hidden>
             {bars.map((v, i) => (
               <i key={i} style={{ height: `${20 + Math.round((v / 255) * 80)}%` }} />

--- a/apps/desktop/src/renderer/src/components/QqMedia.tsx
+++ b/apps/desktop/src/renderer/src/components/QqMedia.tsx
@@ -417,8 +417,9 @@ export function QqVoice({ data, sendTimeMs }: { data: Data; sendTimeMs: number }
 
   // Bar count tracks duration (QQ-style: longer clip → longer strip), with a
   // floor so short clips — notably AI 声聊, which are often 1–5s — always show a
-  // visible waveform, and a cap so very long clips stay within the bubble.
-  const barCount = Math.max(12, Math.min(36, 8 + Math.round(seconds)));
+  // visible waveform, and a cap so very long clips stay within the bubble (the
+  // wave area also clips as a hard safety net; see .qq-media-voice-wave).
+  const barCount = Math.max(12, Math.min(28, 8 + Math.round(seconds)));
   const bars = sampleBars(waveform, barCount);
   const hasResult = transcript !== null || transcribeError !== null;
 

--- a/apps/desktop/src/renderer/src/components/QqMessageContent.tsx
+++ b/apps/desktop/src/renderer/src/components/QqMessageContent.tsx
@@ -581,7 +581,17 @@ export function QqMessageContent({
         </div>
       );
     }
-    // Lone file/voice still sit in a normal bubble (cards, not stickers).
+    // A lone voice owns its own chrome: the play strip IS the bubble, so we
+    // strip the surrounding message bubble (qq-voice-only) — that lets the
+    // 转文字 button and transcript sit OUTSIDE the voice bubble.
+    if (lone.type === 'ptt') {
+      return (
+        <div className={cn('message-content', 'qq-message-inline', 'qq-voice-only')}>
+          <MediaNode element={lone} sendTimeMs={sendTimeMs} msgId={msgId} />
+        </div>
+      );
+    }
+    // Lone file still sits in a normal bubble (a card, not a sticker).
     if (lone.type && MEDIA_KINDS.has(lone.type)) {
       return (
         <div className={cn('message-content', 'qq-message-inline')}>

--- a/apps/desktop/src/renderer/src/components/QqMessageContent.tsx
+++ b/apps/desktop/src/renderer/src/components/QqMessageContent.tsx
@@ -515,7 +515,8 @@ export function QqMessageContent({
       <div className={cn('message-content', 'qq-card-only', 'qq-has-wallet')}>
         <QqWallet
           detail={walletElement.data?.walletDetail}
-          fallbackType={walletElement.data?.walletRedbagType}
+          redbagType={walletElement.data?.walletRedbagType}
+          designatedUin={walletElement.data?.walletDesignatedUin}
         />
       </div>
     );

--- a/apps/desktop/src/renderer/src/components/QqMessageContent.tsx
+++ b/apps/desktop/src/renderer/src/components/QqMessageContent.tsx
@@ -373,9 +373,32 @@ function origSenderDisplay(data: Record<string, unknown>): string | null {
 }
 
 /**
+ * Which quoted elements to preview in the reply box (QQ-style, not just the
+ * single last element):
+ *   - the message ends in media (image / video / file / sticker / …) → preview
+ *     JUST that trailing media (its thumbnail / bracket label);
+ *   - the message ends in inline content (text / @ / face) → preview the whole
+ *     trailing run of inline elements (walk back until a media element or the
+ *     start), so "@a 在吗😊" shows in full instead of only the last "😊".
+ */
+function replyPreviewElements(origElements: RenderElement[]): RenderElement[] {
+  const meaningful = origElements.filter(isMeaningful);
+  const last = meaningful[meaningful.length - 1];
+  if (!last) return [];
+  if (!isTextLike(last)) return [last];
+  const run: RenderElement[] = [];
+  for (let i = meaningful.length - 1; i >= 0; i--) {
+    const el = meaningful[i];
+    if (!el || !isTextLike(el)) break;
+    run.unshift(el);
+  }
+  return run;
+}
+
+/**
  * The darker quote box for a `reply` element. Two lines:
  *   line 1 — the original sender's nickname (resolved by the host),
- *   line 2 — a compact preview of the referenced message's last element
+ *   line 2 — a compact preview of the referenced message's trailing elements
  *           with the jump-arrow tucked at its end.
  * Clicking anywhere on the box asks the host to scroll to that message.
  */
@@ -388,8 +411,7 @@ function ReplyQuote({
 }) {
   const jumpToSeq = useContext(ReplyJumpContext);
   const origElements = Array.isArray(data.origElements) ? (data.origElements as RenderElement[]) : [];
-  const meaningful = origElements.filter(isMeaningful);
-  const preview = meaningful.length > 0 ? meaningful[meaningful.length - 1] : null;
+  const previewEls = replyPreviewElements(origElements);
   const senderName = origSenderDisplay(data);
   const quoteTimeMs = quoteSendTimeMs(data, sendTimeMs);
   // Pass both 40003 candidates; the host picks by conversation kind. Verified
@@ -419,7 +441,13 @@ function ReplyQuote({
       <div className="qq-reply-quote-stack">
         <div className="qq-reply-quote-sender">{senderName ?? '原消息'}</div>
         <div className="qq-reply-quote-body">
-          {preview ? <ReplyPreviewNode element={preview} sendTimeMs={quoteTimeMs} /> : <span>引用消息</span>}
+          {previewEls.length > 0 ? (
+            previewEls.map((element, i) => (
+              <ReplyPreviewNode key={`rp-${i}`} element={element} sendTimeMs={quoteTimeMs} />
+            ))
+          ) : (
+            <span>引用消息</span>
+          )}
           {canJump ? <ArrowUp className="qq-reply-quote-arrow" size={12} strokeWidth={2.4} aria-hidden /> : null}
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/components/QqWallet.tsx
+++ b/apps/desktop/src/renderer/src/components/QqWallet.tsx
@@ -1,21 +1,27 @@
 /**
  * Renders a `wallet` element (QQ 钱包：转账 / 红包) from its `walletDetail`.
  *
- * The kind is decided by `walletDetail.redbagType`:
- *   - 1 → 转账 (transfer): the blue card ported from the demo. The amount line
- *         comes from `redbagTitle`, the note from `openPrompt`, footer is 转账.
- *   - 2 → 口令红包 (password packet): the `password_bag.png` bag, `redbagTitle`
- *         written cream-coloured dead-centre.
- *   - 4 → 普通红包 (normal packet): the `normal_bag.png` bag, same overlay.
- *   - anything else → treated as 4 (normal packet).
+ * 类型判定优先用元素级 walletRedbagType (wire tag 48412，见 codec RedbagType)，
+ * 它能细分拼手气 / 专属 / 语音等；仅当缺失时回退到 walletDetail.redbagType
+ * (tag 48442，粗粒度：1=转账 / 2=口令 / 4=普通)。
  *
- * `walletDetail` already reaches the renderer via mapWallet (no backend change).
- * Bag images live in the repo `resources/img/` tree and are served over
- * `weq-asset://` (CSP-allowed); we never hit the network.
+ *   - 转账 (TRANSFER=1)：蓝色转账卡片。
+ *   - 口令红包 (PASSWORD=6)：password_bag.png 封面。
+ *   - 其它红包：normal_bag.png 封面。
+ *
+ * 除转账外，卡片上方居中用小字标注红包类型（普通 / 拼手气 / 口令 / 语音）。
+ * 专属红包 (DESIGNATED=8) 额外带 walletDesignatedUin：显示该群友的小头像 +
+ * 「给{昵称}的专属红包」（昵称按 uin 走 getProfileByUin 解析）。
+ *
+ * `walletDetail` / walletRedbagType / walletDesignatedUin 均由 mapWallet 透出
+ * （无需后端改动）。Bag 图存在仓库 `resources/img/`，经 `weq-asset://` 提供
+ * （CSP 放行），从不走网络。
  */
 
-import type { ReactElement } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
 import { resourceUrl } from '../lib/resourceUrl';
+import { QqAvatar } from './QqAvatar';
+import { client } from '../trpc/client';
 
 // ---- helpers -------------------------------------------------------------
 
@@ -32,22 +38,66 @@ function formatAmount(raw: string): string {
   return t;
 }
 
+/** 红包类型小字（walletRedbagType / wire tag 48412，见 codec RedbagType）。 */
+const REDBAG_LABEL: Record<number, string> = {
+  2: '普通红包',
+  3: '拼手气红包',
+  6: '口令红包',
+  8: '专属红包',
+  15: '语音红包',
+};
+
+/** 按 uin 解析昵称（专属红包指定领取人）。查无则回退显示 uin。 */
+function useNickByUin(uin: string | null): string | null {
+  const [nick, setNick] = useState<string | null>(null);
+  useEffect(() => {
+    setNick(null);
+    if (!uin) return;
+    let alive = true;
+    void client.account.getProfileByUin
+      .query({ uin })
+      .then((p) => {
+        if (alive) setNick(p?.nick || null);
+      })
+      .catch(() => {
+        /* 离线 / 查无：保持 null，调用方回退 uin */
+      });
+    return () => {
+      alive = false;
+    };
+  }, [uin]);
+  return nick;
+}
+
 // ---- the wallet card -----------------------------------------------------
 
 export function QqWallet({
   detail,
-  fallbackType,
+  redbagType,
+  designatedUin,
 }: {
   detail: unknown;
-  fallbackType?: unknown;
+  /** 元素级 walletRedbagType（tag 48412）。 */
+  redbagType?: unknown;
+  /** 专属红包指定领取人 uin（tag 48420）。 */
+  designatedUin?: unknown;
 }): ReactElement {
   const d = detail && typeof detail === 'object' ? (detail as Record<string, unknown>) : {};
-  const type = Number(d.redbagType ?? fallbackType);
+  // 细粒度类型（48412）优先；缺失时回退粗粒度嵌套类型（48442）。
+  const fine = Number(redbagType);
+  const fineKnown = Number.isFinite(fine) && fine > 0;
+  const coarse = Number(d.redbagType);
   const title = str(d, 'redbagTitle');
   const prompt = str(d, 'openPrompt');
 
+  const uin =
+    designatedUin != null && String(designatedUin) !== '0' ? String(designatedUin) : null;
+  const isDesignated = (fine === 8 || uin != null) && uin != null;
+  const nick = useNickByUin(isDesignated ? uin : null);
+
   // redbagType 1 → 转账卡片。
-  if (type === 1) {
+  const isTransfer = fine === 1 || (!fineKnown && coarse === 1);
+  if (isTransfer) {
     const amount = formatAmount(title);
     return (
       <div className="weq-transfer-card">
@@ -81,11 +131,30 @@ export function QqWallet({
     );
   }
 
-  // 其余按红包处理：2 → 口令红包，其它(含 4) → 普通红包。
-  const bagImage = type === 2 ? 'password_bag.png' : 'normal_bag.png';
+  // 口令红包（48412=6，或缺失时嵌套 48442=2）→ password_bag，其余 → normal_bag。
+  const isPassword = fine === 6 || (!fineKnown && coarse === 2);
+  const bagImage = isPassword ? 'password_bag.png' : 'normal_bag.png';
+  const label = fineKnown ? REDBAG_LABEL[fine] : undefined;
+
   return (
-    <div className="weq-redbag-card" title={title || undefined}>
-      <img className="weq-redbag-img" src={resourceUrl('img', bagImage)} alt="" draggable={false} />
+    <div
+      className={`weq-redbag-card${isDesignated ? ' weq-redbag-card--designated' : ''}`}
+      title={title || undefined}
+    >
+      <img
+        className="weq-redbag-img"
+        src={resourceUrl('img', bagImage)}
+        alt=""
+        draggable={false}
+      />
+      {isDesignated ? (
+        <div className="weq-redbag-tag weq-redbag-tag--designated">
+          <QqAvatar uin={uin} size={22} className="weq-redbag-tag-avatar" />
+          <span>给{nick || uin}的专属红包</span>
+        </div>
+      ) : label ? (
+        <div className="weq-redbag-tag">{label}</div>
+      ) : null}
       {title ? <span className="weq-redbag-title">{title}</span> : null}
     </div>
   );

--- a/apps/desktop/src/renderer/src/components/RailAccountFooter.tsx
+++ b/apps/desktop/src/renderer/src/components/RailAccountFooter.tsx
@@ -17,10 +17,11 @@ import { useCallback, useEffect, useRef, useState, type ReactElement } from 'rea
 import { createPortal } from 'react-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { getQueryKey } from '@trpc/react-query';
-import { LockKeyhole, LogOut, Trash2 } from 'lucide-react';
+import { LockKeyhole, LogOut, Moon, Sun, Trash2 } from 'lucide-react';
 import { trpc, client } from '../trpc/client';
 import { useViewState } from '../state/view';
 import { useAppLock } from '../state/lock';
+import { useThemeStore } from '../state/theme';
 import { useDialog } from './Dialog';
 import { QqAvatar } from './QqAvatar';
 
@@ -41,6 +42,11 @@ export function RailAccountFooter({
   const goTo = useViewState((s) => s.goTo);
   const showError = useDialog((s) => s.showError);
   const lock = useAppLock((s) => s.lock);
+  // Manual 深/浅 toggle sitting above the lock button. Reuses the global theme
+  // store — flipping here also updates the settings page (跟随系统 can still be
+  // chosen there; a click just pins one concrete mode).
+  const resolvedTheme = useThemeStore((s) => s.resolved);
+  const setThemePreference = useThemeStore((s) => s.setPreference);
   const queryClient = useQueryClient();
 
   const [open, setOpen] = useState(false);
@@ -75,6 +81,12 @@ export function RailAccountFooter({
     }
     setOpen(false);
     lock();
+  }
+
+  function toggleTheme(): void {
+    // Pin the opposite of whatever is currently showing. From 跟随系统 this
+    // still does the intuitive thing: flips away from the resolved mode.
+    setThemePreference(resolvedTheme === 'dark' ? 'light' : 'dark');
   }
 
   // Right-click context menu for account items
@@ -232,6 +244,19 @@ export function RailAccountFooter({
 
   return (
     <>
+      <button
+        type="button"
+        className="weq-rail-theme-btn"
+        title={resolvedTheme === 'dark' ? '切换到浅色模式' : '切换到深色模式'}
+        aria-label={resolvedTheme === 'dark' ? '切换到浅色模式' : '切换到深色模式'}
+        onClick={toggleTheme}
+      >
+        {resolvedTheme === 'dark' ? (
+          <Sun size={18} strokeWidth={1.8} aria-hidden />
+        ) : (
+          <Moon size={18} strokeWidth={1.8} aria-hidden />
+        )}
+      </button>
       <button
         type="button"
         className="weq-rail-lock-btn"

--- a/apps/desktop/src/renderer/src/components/VideoLightbox.tsx
+++ b/apps/desktop/src/renderer/src/components/VideoLightbox.tsx
@@ -8,13 +8,15 @@
  *
  * Sibling of {@link ImageLightbox}; kept separate because it renders a `<video>`
  * (controls / autoplay / range streaming) rather than an `<img>`. Click the
- * backdrop or press ESC to close.
+ * backdrop or press ESC to close. Scroll to zoom (anchored at the cursor) and
+ * drag to pan when zoomed; single click is left to the native play/pause.
  */
 
 import { useEffect, type ReactElement } from 'react';
 import { createPortal } from 'react-dom';
 import { create } from 'zustand';
 import { X } from 'lucide-react';
+import { useZoomPan } from './useZoomPan';
 
 interface VideoLightboxStore {
   src: string | null;
@@ -45,6 +47,7 @@ export function VideoLightbox(): ReactElement | null {
   const src = useVideoLightbox((s) => s.src);
   const poster = useVideoLightbox((s) => s.poster);
   const close = useVideoLightbox((s) => s.close);
+  const zoom = useZoomPan(src, { clickZoom: false });
 
   useEffect(() => {
     if (!src) return;
@@ -62,15 +65,19 @@ export function VideoLightbox(): ReactElement | null {
       <button className="weq-lightbox-close" type="button" onClick={close} aria-label="关闭">
         <X size={22} />
       </button>
-      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-      <video
-        className="weq-lightbox-image weq-anim-pop"
-        src={src}
-        poster={poster || undefined}
-        controls
-        autoPlay
-        onMouseDown={(event) => event.stopPropagation()}
-      />
+      <div className="weq-lightbox-stage weq-anim-pop" onMouseDown={(event) => event.stopPropagation()}>
+        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+        <video
+          ref={zoom.setEl}
+          className="weq-lightbox-image"
+          src={src}
+          poster={poster || undefined}
+          controls
+          autoPlay
+          style={zoom.style}
+          onMouseDown={zoom.onMouseDown}
+        />
+      </div>
     </div>,
     document.body,
   );

--- a/apps/desktop/src/renderer/src/components/analyticsCharts.tsx
+++ b/apps/desktop/src/renderer/src/components/analyticsCharts.tsx
@@ -13,6 +13,27 @@ import { cn } from "../im-template/template/classNames";
 
 export const ACCENT = "var(--weq-accent-effective)";
 
+/**
+ * Accent-following categorical palette. Every entry is a `color-mix` dominated
+ * by the picked accent, so a multi-category chart reads as one cohesive theme
+ * colour instead of a clashing rainbow — the categories stay distinguishable
+ * via a small hue nudge, but the whole thing follows 设置里的主题色. Mirrors the
+ * WordCloud approach below.
+ */
+export const ACCENT_SERIES = [
+  "var(--weq-accent-effective)",
+  "color-mix(in srgb, var(--weq-accent-effective) 80%, #8b5cf6)",
+  "color-mix(in srgb, var(--weq-accent-effective) 72%, #06b6d4)",
+  "color-mix(in srgb, var(--weq-accent-effective) 74%, #22c55e)",
+  "color-mix(in srgb, var(--weq-accent-effective) 76%, #f59e0b)",
+  "color-mix(in srgb, var(--weq-accent-effective) 72%, #ec4899)",
+  "color-mix(in srgb, var(--weq-accent-effective) 64%, #f43f5e)",
+  "color-mix(in srgb, var(--weq-fg-primary) 42%, var(--weq-accent-effective))",
+] as const;
+
+/** A soft, theme-neutral colour for a "misc/其它" slice. */
+export const ACCENT_MUTED = "color-mix(in srgb, var(--weq-fg-primary) 26%, transparent)";
+
 export interface DailyActivityItem {
   date: string;
   count: number;

--- a/apps/desktop/src/renderer/src/components/compose/AddMessageModal.tsx
+++ b/apps/desktop/src/renderer/src/components/compose/AddMessageModal.tsx
@@ -36,9 +36,11 @@ import { MessagePicker, type PickedMessage } from './MessagePicker';
 import {
   hasContent,
   nextId,
+  replyTrailingIsPic,
   summarize,
   toPreviewElements,
   toReplyElement,
+  toReplyOrigElements,
   toWireElements,
   type ReplyTarget,
   type Segment,
@@ -118,6 +120,38 @@ export function AddMessageModal({
   }
   function updateText(id: string, text: string): void {
     setSegments((prev) => prev.map((s) => (s.id === id && s.t === 'text' ? { ...s, text } : s)));
+  }
+
+  /**
+   * Commit a reply target. When the quoted message ends in an image, lift the
+   * real `pic` element (getRawElements → editable wire) into origElements so the
+   * stored quote renders an actual thumbnail; otherwise carry the trailing
+   * text/@/face run. Any lift failure degrades to the bracket-label preview.
+   */
+  async function pickReply(m: PickedMessage): Promise<void> {
+    const base: ReplyTarget = {
+      msgId: m.msgId,
+      msgSeq: m.msgSeq,
+      senderUid: m.senderUid,
+      senderUin: m.senderUin,
+      sendTime: m.sendTime,
+      summary: summarize(m.elements ?? []),
+      origElements: toReplyOrigElements(m.elements ?? []),
+    };
+    if (replyTrailingIsPic(m.elements ?? [])) {
+      try {
+        const raw = await client.account.getRawElements.query({ msgId: m.msgId });
+        // The trailing image — findLast, not find: a multi-image message quotes
+        // its LAST picture (the one the preview rule selected).
+        const pics = (raw?.elements ?? []).filter((e: { kind?: string }) => e.kind === 'pic');
+        const picCodec = pics[pics.length - 1] as Record<string, unknown> | undefined;
+        if (picCodec) base.origElements = [picCodec];
+      } catch {
+        /* keep the bracket-label fallback from toReplyOrigElements */
+      }
+    }
+    setReplyTarget(base);
+    setView('main');
   }
 
   async function pickImage(msg: PickedMessage): Promise<void> {
@@ -343,17 +377,7 @@ export function AddMessageModal({
                 kind={kind}
                 conv={conv}
                 resolveName={resolveName}
-                onPick={(m) => {
-                  setReplyTarget({
-                    msgId: m.msgId,
-                    msgSeq: m.msgSeq,
-                    senderUid: m.senderUid,
-                    senderUin: m.senderUin,
-                    sendTime: m.sendTime,
-                    summary: summarize(m.elements ?? []),
-                  });
-                  setView('main');
-                }}
+                onPick={(m) => void pickReply(m)}
               />
             ) : null}
             {view === 'pic' ? (

--- a/apps/desktop/src/renderer/src/components/compose/DeletedMessagesModal.tsx
+++ b/apps/desktop/src/renderer/src/components/compose/DeletedMessagesModal.tsx
@@ -1,0 +1,139 @@
+/**
+ * DeletedMessagesModal — browse a conversation's soft-deleted (hidden but
+ * restorable) messages and bring any of them back.
+ *
+ * To stay visually identical to the live chat, it renders each deleted message
+ * with the SAME `MessageBubble` + renderers the chat pane uses, inside a
+ * `message-scroll` container. The only extra affordance is a per-message
+ * “恢复” button. Message objects are built by the caller (MainView) through the
+ * exact `messageToTemplate` pipeline, so senders/avatars/replies match the chat.
+ */
+
+import { useMemo, useState, type ReactElement } from 'react';
+import { RotateCcw, Trash2, X } from 'lucide-react';
+import { Modal } from '../Dialog';
+import { ConvContext, ForwardKindContext } from '../QqMessageContent';
+import { cn } from '../../im-template/template/classNames';
+import { MessageBubble } from '../../im-template/template/messageBubble';
+import { resolveMessageSender } from '../../im-template/template/conversationDisplay';
+import { displayUserName } from '../../im-template/template/user';
+import type { MessageRenderer } from '../../im-template/template/messageRenderers';
+import type { Conversation, Message, User } from '../../im-template/template/types';
+
+const noop = (): void => {};
+
+export function DeletedMessagesModal({
+  conversation,
+  user,
+  messages,
+  renderers,
+  loading,
+  onRestore,
+  onClose,
+}: {
+  conversation: Conversation;
+  user: User;
+  /** Deleted messages, newest-first→ASC, already built via messageToTemplate. */
+  messages: Message[];
+  renderers?: MessageRenderer[];
+  loading: boolean;
+  /** Restore one message; resolves once the DB row is un-hidden. */
+  onRestore: (msgId: string) => Promise<void>;
+  onClose: () => void;
+}): ReactElement {
+  const isGroup = conversation.type === 'group';
+  const convKey = isGroup ? conversation.group.identityValue : '';
+  const showSenderNames = conversation.type !== 'direct';
+  const subtitle = isGroup ? conversation.group.name : conversation.otherUser.displayName;
+
+  // Optimistically drop a row the instant its restore resolves, so the panel
+  // feels live even before the parent refetches.
+  const [restoredIds, setRestoredIds] = useState<Set<string>>(new Set());
+  const [restoringId, setRestoringId] = useState<string | null>(null);
+
+  const visible = useMemo(
+    () => messages.filter((m) => !restoredIds.has(m.id)),
+    [messages, restoredIds],
+  );
+
+  async function restore(message: Message): Promise<void> {
+    if (restoringId) return;
+    setRestoringId(message.id);
+    try {
+      await onRestore(message.id);
+      setRestoredIds((prev) => new Set(prev).add(message.id));
+    } catch {
+      /* leave the row in place on failure; parent surfaces the error */
+    } finally {
+      setRestoringId(null);
+    }
+  }
+
+  return (
+    <Modal onClose={onClose} width={520} labelledBy="weq-deleted-title">
+      <div className="weq-deleted">
+        <header className="weq-compose-head">
+          <div className="weq-compose-titlewrap">
+            <strong id="weq-deleted-title" className="weq-compose-title">查看删除消息</strong>
+            <span className="weq-compose-sub">{subtitle}</span>
+          </div>
+          <button type="button" className="weq-compose-x" onClick={onClose} title="关闭">
+            <X size={17} />
+          </button>
+        </header>
+
+        <ForwardKindContext.Provider value={isGroup ? 'group' : 'c2c'}>
+          <ConvContext.Provider value={convKey}>
+            <div className={cn('message-scroll', 'weq-deleted-scroll')}>
+              {loading ? (
+                <div className="weq-deleted-empty">加载中…</div>
+              ) : visible.length === 0 ? (
+                <div className="weq-deleted-empty">
+                  <Trash2 size={26} />
+                  <span>没有已删除的消息</span>
+                  <small>在聊天里右键消息「删除」后，会出现在这里，可随时恢复。</small>
+                </div>
+              ) : (
+                visible.map((message) => {
+                  const mine = message.senderId === user.id;
+                  const sender = resolveMessageSender(message, conversation, user);
+                  return (
+                    <div key={message.id} className="weq-deleted-row">
+                      <div className="weq-deleted-bubble">
+                        <MessageBubble
+                          message={message}
+                          conversation={conversation}
+                          sender={sender}
+                          mine={mine}
+                          senderName={displayUserName(sender)}
+                          senderAvatarUrl={sender.avatarUrl}
+                          senderSeed={sender.identityValue}
+                          senderKind={sender.kind}
+                          showSenderName={showSenderNames}
+                          active={false}
+                          renderers={renderers}
+                          onContextMenu={noop}
+                          onLongPress={noop}
+                        />
+                      </div>
+                      <button
+                        type="button"
+                        className="weq-deleted-restore"
+                        title="恢复这条消息"
+                        disabled={restoringId === message.id}
+                        onClick={() => void restore(message)}
+                      >
+                        <RotateCcw size={14} />
+                        <span>{restoringId === message.id ? '恢复中…' : '恢复'}</span>
+                      </button>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </ConvContext.Provider>
+        </ForwardKindContext.Provider>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/compose/composeModel.ts
+++ b/apps/desktop/src/renderer/src/components/compose/composeModel.ts
@@ -26,6 +26,12 @@ export interface ReplyTarget {
   sendTime: string;
   /** Plain-text summary shown in the quote line. */
   summary: string;
+  /**
+   * The quoted message's trailing elements (kind-tagged; encoded to wire by the
+   * backend) so the stored reply quote renders real face/@/text instead of a
+   * flattened "[表情]" string. Empty ⇒ fall back to a text summary element.
+   */
+  origElements?: Array<Record<string, unknown>>;
 }
 
 /** The render-view element shape consumed by QqMessageContent. */
@@ -79,11 +85,17 @@ export function toWireElements(segs: Segment[]): Array<Record<string, unknown>> 
 /**
  * Build the leading `reply` element from a picked target. Group replies omit
  * origReceiverUid/origMsgIndex in the wild, but the compose schema requires them,
- * so we supply harmless fillers. `origElements` carries a single synthesized text
- * element so the stored quote renders a preview instead of "引用消息".
+ * so we supply harmless fillers. `origElements` carries the quoted message's
+ * trailing elements (kind-tagged; encoded to wire by the backend) so the stored
+ * quote renders real face/@/text; it falls back to a single synthesized text
+ * element when none were captured.
  */
 export function toReplyElement(target: ReplyTarget, peerUid: string): Record<string, unknown> {
   const seqNum = Number(target.msgSeq) || 0;
+  const origElements =
+    target.origElements && target.origElements.length > 0
+      ? target.origElements
+      : [{ kind: 'text', textContent: target.summary || '引用消息' }];
   return {
     kind: 'reply',
     origSenderUid: target.senderUid,
@@ -95,8 +107,88 @@ export function toReplyElement(target: ReplyTarget, peerUid: string): Record<str
     origMsgId: target.msgId,
     origMsgIndex: seqNum,
     replyFlag47422: target.msgId,
-    origElements: [{ elementType: 1, textContent: target.summary || '引用消息' }],
+    origElements,
   };
+}
+
+/** Media kinds we can't re-author as real quoted elements in the compose tool;
+ * previewed as a bracket label instead of their (unavailable) CDN payload. */
+const REPLY_MEDIA_LABEL: Record<string, string> = {
+  pic: '[图片]',
+  video: '[视频]',
+  file: '[文件]',
+  ptt: '[语音]',
+  mface: '[动画表情]',
+  onlineFile: '[在线文件]',
+  onlineFolder: '[在线文件夹]',
+};
+
+/** An origElements element is "meaningful" unless it's empty text. */
+function isMeaningfulEl(e: RenderEl): boolean {
+  if (e.type === 'text') return String(e.data?.textContent ?? '').length > 0;
+  return true;
+}
+
+/** Inline (text-run) kinds — coalesced when trailing, mirrors the reply quote. */
+function isInlineEl(e: RenderEl): boolean {
+  return e.type === 'text' || e.type === 'at' || e.type === 'face';
+}
+
+/**
+ * True when a picked message's reply preview is a single trailing image — the
+ * caller then lifts the real `pic` element (via getRawElements) so the stored
+ * quote shows an actual thumbnail rather than the "[图片]" bracket label.
+ */
+export function replyTrailingIsPic(elements: RenderEl[]): boolean {
+  const meaningful = elements.filter((e) => e.type !== 'reply' && isMeaningfulEl(e));
+  const last = meaningful[meaningful.length - 1];
+  return !!last && last.type === 'pic';
+}
+
+/** One picked-message render element → a kind-tagged wire element for storage. */
+function toOrigElement(e: RenderEl): Record<string, unknown> {
+  const data = e.data ?? {};
+  switch (e.type) {
+    case 'text':
+      return { kind: 'text', textContent: String(data.textContent ?? '') };
+    case 'at':
+      return {
+        kind: 'at',
+        textContent: String(data.textContent ?? ''),
+        // mapAt stores the target uid under `buddleId` (sic); decodeElement keys
+        // 'at' off a present `bubbleId`, so restore the correct wire field name.
+        bubbleId: String(data.buddleId ?? data.bubbleId ?? ''),
+      };
+    case 'face':
+      return { kind: 'face', faceId: Number(data.faceId) || 0, faceText: String(data.faceText ?? '') };
+    default:
+      return { kind: 'text', textContent: REPLY_MEDIA_LABEL[e.type ?? ''] ?? '[消息]' };
+  }
+}
+
+/**
+ * Build a reply target's `origElements` from a picked message's render elements,
+ * mirroring the reply-quote render rule: if the message ends in media, carry just
+ * that trailing media (as a bracket-label text — its CDN payload isn't
+ * re-authorable here); otherwise carry the trailing run of inline text/@/face so
+ * the quote shows them for real (face renders as the actual emoji).
+ */
+export function toReplyOrigElements(elements: RenderEl[]): Array<Record<string, unknown>> {
+  const meaningful = elements.filter((e) => e.type !== 'reply' && isMeaningfulEl(e));
+  const last = meaningful[meaningful.length - 1];
+  if (!last) return [];
+  let run: RenderEl[];
+  if (!isInlineEl(last)) {
+    run = [last];
+  } else {
+    run = [];
+    for (let i = meaningful.length - 1; i >= 0; i--) {
+      const el = meaningful[i];
+      if (!el || !isInlineEl(el)) break;
+      run.unshift(el);
+    }
+  }
+  return run.map(toOrigElement);
 }
 
 /** Convert authored segments into render elements for the live preview. */

--- a/apps/desktop/src/renderer/src/components/settings/GlobalSettingsSection.tsx
+++ b/apps/desktop/src/renderer/src/components/settings/GlobalSettingsSection.tsx
@@ -16,7 +16,18 @@
  */
 
 import { useEffect, useState, type ReactElement } from 'react';
-import { Check, FolderOpen, Info, LockKeyhole, Minimize2, RotateCcw, User } from 'lucide-react';
+import {
+  Check,
+  FolderOpen,
+  HardDrive,
+  Info,
+  Loader2,
+  LockKeyhole,
+  Minimize2,
+  RotateCcw,
+  Trash2,
+  User,
+} from 'lucide-react';
 import type { WindowCloseBehavior } from '@weq/service';
 import { trpc } from '../../trpc/client';
 import { useDialog } from '../Dialog';
@@ -28,6 +39,19 @@ import logoUrl from '@resources/brand/logo.png';
 
 function errMsg(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
+}
+
+/** Human-readable byte size for the cache-cleanup card. */
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes < 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(unit === 0 ? 0 : value >= 100 ? 0 : 1)} ${units[unit]}`;
 }
 
 /** 空闲自动锁定时长选项。0 = 关闭（仍可手动上锁）。 */
@@ -48,6 +72,7 @@ const CLOSE_BEHAVIOR_OPTIONS: ReadonlyArray<{ value: WindowCloseBehavior; label:
 
 export function GlobalSettingsSection(): ReactElement {
   const showError = useDialog((s) => s.showError);
+  const confirm = useDialog((s) => s.confirm);
   const pushToast = useToast((s) => s.push);
   const [systemAuthStatus, setSystemAuthStatus] = useState<Awaited<
     ReturnType<typeof window.weq.systemAuth.getStatus>
@@ -87,6 +112,19 @@ export function GlobalSettingsSection(): ReactElement {
   const setAutoLock = trpc.bootstrap.setAutoLockMinutes.useMutation();
   const setWindowClose = trpc.bootstrap.setWindowCloseBehavior.useMutation();
   const cacheBusy = pickCache.isLoading || clearCache.isLoading;
+
+  // ---- WeQ 缓存清理（头像/媒体/商城表情/语音，均可重下）----
+  const cacheUsage = trpc.bootstrap.listClearableCache.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+    staleTime: 0,
+    refetchOnMount: 'always',
+  });
+  const clearWeqCache = trpc.bootstrap.clearWeqCache.useMutation();
+  // Which categories are checked for cleanup. Empty set + a click on 清理 means
+  // "clear everything listed"; individual checkboxes narrow it down.
+  const [pickedCats, setPickedCats] = useState<Set<string>>(new Set());
+  const cacheItems = cacheUsage.data ?? [];
+  const totalCacheBytes = cacheItems.reduce((sum, it) => sum + it.bytes, 0);
 
   useEffect(() => {
     const minutes = settings.data?.autoLockMinutes;
@@ -130,6 +168,42 @@ export function GlobalSettingsSection(): ReactElement {
       pushToast({ tone: 'success', title: '已重置为默认缓存目录' });
     } catch (e) {
       showError('重置缓存目录失败', errMsg(e));
+    }
+  }
+
+  function toggleCat(id: string): void {
+    setPickedCats((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function onClearWeqCache(): Promise<void> {
+    const ids = [...pickedCats];
+    // Nothing selected → clear all listed categories.
+    const targets = ids.length > 0 ? cacheItems.filter((c) => pickedCats.has(c.id)) : cacheItems;
+    const willFree = targets.reduce((sum, it) => sum + it.bytes, 0);
+    const label =
+      ids.length > 0 ? targets.map((t) => t.label).join('、') : '全部可清理缓存';
+    const ok = await confirm(
+      '清理 WeQ 缓存',
+      `将删除「${label}」，预计释放约 ${formatBytes(willFree)}。这些缓存会在下次需要时自动重新下载，不影响聊天记录。是否继续？`,
+      { okLabel: '清理', cancelLabel: '取消', tone: 'warning' },
+    );
+    if (!ok) return;
+    try {
+      const res = await clearWeqCache.mutateAsync(ids.length > 0 ? { ids } : undefined);
+      await cacheUsage.refetch();
+      setPickedCats(new Set());
+      pushToast({
+        tone: 'success',
+        title: '缓存已清理',
+        message: `释放约 ${formatBytes(res.freedBytes)}`,
+      });
+    } catch (e) {
+      showError('清理缓存失败', errMsg(e));
     }
   }
 
@@ -391,6 +465,53 @@ export function GlobalSettingsSection(): ReactElement {
             </div>
           }
         />
+      </Card>
+
+      {/* Clear WeQ cache */}
+      <Card title="清理缓存">
+        <p className="weq-set-note">
+          <Info size={12} strokeWidth={1.9} aria-hidden /> 以下缓存均可在需要时自动重新下载，
+          删除不影响聊天记录、克隆体数据与导出产物。默认清理全部，也可勾选后单独清理。
+        </p>
+        <div className="weq-set-cache-list">
+          {cacheUsage.isLoading ? (
+            <div className="weq-set-empty">读取缓存占用中…</div>
+          ) : cacheItems.length === 0 ? (
+            <div className="weq-set-empty">暂无可清理的缓存</div>
+          ) : (
+            cacheItems.map((item) => (
+              <label key={item.id} className="weq-set-cache-item">
+                <input
+                  type="checkbox"
+                  checked={pickedCats.has(item.id)}
+                  onChange={() => toggleCat(item.id)}
+                  disabled={clearWeqCache.isLoading}
+                />
+                <HardDrive size={14} strokeWidth={1.8} aria-hidden />
+                <span className="weq-set-cache-label">{item.label}</span>
+                <span className="weq-set-cache-size weq-number">{formatBytes(item.bytes)}</span>
+              </label>
+            ))
+          )}
+        </div>
+        <div className="weq-set-actions">
+          <span className="weq-set-cache-total">
+            合计占用 <strong className="weq-number">{formatBytes(totalCacheBytes)}</strong>
+          </span>
+          <button
+            type="button"
+            className="weq-set-btn weq-set-btn-danger"
+            disabled={clearWeqCache.isLoading || cacheItems.length === 0 || totalCacheBytes === 0}
+            onClick={() => void onClearWeqCache()}
+          >
+            {clearWeqCache.isLoading ? (
+              <Loader2 size={14} strokeWidth={1.8} className="weq-spin" aria-hidden />
+            ) : (
+              <Trash2 size={14} strokeWidth={1.8} aria-hidden />
+            )}
+            {pickedCats.size > 0 ? '清理所选' : '清理全部'}
+          </button>
+        </div>
       </Card>
 
       <Card title="日志">

--- a/apps/desktop/src/renderer/src/components/useZoomPan.ts
+++ b/apps/desktop/src/renderer/src/components/useZoomPan.ts
@@ -15,7 +15,7 @@ import { useCallback, useEffect, useRef, useState, type CSSProperties } from 're
 
 const MIN_SCALE = 1;
 const MAX_SCALE = 8;
-const WHEEL_STEP = 1.35; // 每格滚轮的缩放倍率
+const WHEEL_STEP = 1.15; // 每格滚轮的缩放倍率（越接近 1 越平滑）
 const CLICK_ZOOM = 2; // 单击放大到的倍率
 const DRAG_THRESHOLD = 4; // 超过该位移(px)才算拖拽，否则视为单击
 

--- a/apps/desktop/src/renderer/src/components/useZoomPan.ts
+++ b/apps/desktop/src/renderer/src/components/useZoomPan.ts
@@ -1,0 +1,137 @@
+/**
+ * Zoom / pan interaction for lightbox media (image or video).
+ *
+ *   - 滚轮：以光标为锚点连续缩放（放大处在鼠标下的点保持不动）。
+ *   - 单击：在 1× 与 CLICK_ZOOM 之间切换（可用 clickZoom:false 关闭，
+ *     视频用它把单击留给播放/暂停）。
+ *   - 拖拽：放大后按住拖动平移；1× 时不平移（让视频进度条等原生控件可用）。
+ *   - resetKey（一般传 src）变化时自动复位到 1×、居中。
+ *
+ * 返回一个 callback ref（挂到媒体元素上，用于绑定 passive:false 的 wheel
+ * 监听，以便 preventDefault 阻止页面滚动）、以及要展开到元素上的样式与事件。
+ */
+
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react';
+
+const MIN_SCALE = 1;
+const MAX_SCALE = 8;
+const WHEEL_STEP = 1.35; // 每格滚轮的缩放倍率
+const CLICK_ZOOM = 2; // 单击放大到的倍率
+const DRAG_THRESHOLD = 4; // 超过该位移(px)才算拖拽，否则视为单击
+
+interface Transform {
+  scale: number;
+  tx: number;
+  ty: number;
+}
+
+const IDENTITY: Transform = { scale: 1, tx: 0, ty: 0 };
+
+export interface ZoomPan {
+  /** 挂到媒体元素（img/video）上的 callback ref。 */
+  setEl(el: HTMLElement | null): void;
+  /** 展开到媒体元素上的 transform / cursor 样式。 */
+  style: CSSProperties;
+  onMouseDown(event: React.MouseEvent): void;
+  /** 是否处于放大状态（供外层决定是否显示「重置」按钮等）。 */
+  zoomed: boolean;
+  reset(): void;
+}
+
+function clampScale(s: number): number {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, s));
+}
+
+export function useZoomPan(resetKey: unknown, opts?: { clickZoom?: boolean }): ZoomPan {
+  const clickZoom = opts?.clickZoom ?? true;
+
+  const [t, setT] = useState<Transform>(IDENTITY);
+  const [dragging, setDragging] = useState(false);
+  const [el, setEl] = useState<HTMLElement | null>(null);
+
+  // 事件处理里需要读到「当前」变换，用 ref 镜像 state 避免闭包旧值。
+  const ref = useRef(t);
+  ref.current = t;
+
+  const reset = useCallback(() => setT(IDENTITY), []);
+
+  // 切换媒体（或关闭再开）时复位。
+  useEffect(() => setT(IDENTITY), [resetKey]);
+
+  /** 以 (clientX, clientY) 为锚点缩放到 nextScale，锚点在屏幕上保持不动。 */
+  const zoomAt = useCallback((clientX: number, clientY: number, nextScale: number, rect: DOMRect) => {
+    const cur = ref.current;
+    const s = clampScale(nextScale);
+    if (s === cur.scale) return;
+    if (s <= 1) {
+      setT(IDENTITY);
+      return;
+    }
+    // rect 是元素当前（已变换）的包围盒，其中心即当前屏幕中心。
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const k = 1 - s / cur.scale;
+    setT({ scale: s, tx: cur.tx + (clientX - cx) * k, ty: cur.ty + (clientY - cy) * k });
+  }, []);
+
+  // 滚轮缩放：用原生 non-passive 监听，才能 preventDefault 阻止页面滚动。
+  useEffect(() => {
+    if (!el) return;
+    const onWheel = (event: WheelEvent): void => {
+      event.preventDefault();
+      const rect = el.getBoundingClientRect();
+      const factor = event.deltaY < 0 ? WHEEL_STEP : 1 / WHEEL_STEP;
+      zoomAt(event.clientX, event.clientY, ref.current.scale * factor, rect);
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [el, zoomAt]);
+
+  const onMouseDown = useCallback(
+    (event: React.MouseEvent) => {
+      if (event.button !== 0) return;
+      // 阻止冒泡到遮罩层（否则会触发关闭）。
+      event.stopPropagation();
+      const startX = event.clientX;
+      const startY = event.clientY;
+      const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+      const start = ref.current;
+      let moved = false;
+
+      const onMove = (ev: MouseEvent): void => {
+        const dx = ev.clientX - startX;
+        const dy = ev.clientY - startY;
+        if (!moved && Math.hypot(dx, dy) > DRAG_THRESHOLD) {
+          moved = true;
+          setDragging(true);
+        }
+        // 仅在放大后平移；1× 时不动，避免影响视频原生控件的拖动。
+        if (moved && start.scale > 1) {
+          setT({ scale: start.scale, tx: start.tx + dx, ty: start.ty + dy });
+        }
+      };
+      const onUp = (): void => {
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+        setDragging(false);
+        // 没拖动过 = 单击：在 1× / CLICK_ZOOM 间切换。
+        if (!moved && clickZoom) {
+          const next = ref.current.scale > 1 ? 1 : CLICK_ZOOM;
+          zoomAt(startX, startY, next, rect);
+        }
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
+    },
+    [clickZoom, zoomAt],
+  );
+
+  const style: CSSProperties = {
+    transform: `translate3d(${t.tx}px, ${t.ty}px, 0) scale(${t.scale})`,
+    transition: dragging ? 'none' : 'transform 140ms ease',
+    cursor: t.scale > 1 ? (dragging ? 'grabbing' : 'grab') : clickZoom ? 'zoom-in' : 'default',
+    willChange: 'transform',
+  };
+
+  return { setEl, style, onMouseDown, zoomed: t.scale > 1, reset };
+}

--- a/apps/desktop/src/renderer/src/im-template/styles/chat.css
+++ b/apps/desktop/src/renderer/src/im-template/styles/chat.css
@@ -1028,13 +1028,20 @@ html[data-theme="dark"] .member-badge.level-6 { background-color: rgba(250, 219,
 	.message-content.markdown-image-only,
 /* Card-only QQ elements (合并转发 / ark / 红包 / 闪传) own their own chrome —
  * strip the surrounding bubble background and padding so the card sits flush
- * in the message line. */
+ * in the message line. A lone voice (qq-voice-only) is the same idea: the play
+ * strip is its own bubble, so the 转文字 button sits outside it. */
 .message-content.qq-card-only,
 .message-line.mine .message-content.qq-card-only,
 .message-bubble.context-active .message-content.qq-card-only,
 .message-line.mine
 	.message-bubble.context-active
-	.message-content.qq-card-only {
+	.message-content.qq-card-only,
+.message-content.qq-voice-only,
+.message-line.mine .message-content.qq-voice-only,
+.message-bubble.context-active .message-content.qq-voice-only,
+.message-line.mine
+	.message-bubble.context-active
+	.message-content.qq-voice-only {
 	padding: 0;
 	background: transparent;
 }

--- a/apps/desktop/src/renderer/src/im-template/styles/chat.css
+++ b/apps/desktop/src/renderer/src/im-template/styles/chat.css
@@ -2959,6 +2959,16 @@ html[data-theme="dark"] .member-role-badge.admin {
 	padding: 4px 0;
 }
 
+.ga-members-loading-more {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	padding: 12px 0 4px;
+	font-size: 12px;
+	color: var(--weq-fg-secondary);
+}
+
 .ga-member-card {
 	display: flex;
 	flex-direction: column;

--- a/apps/desktop/src/renderer/src/im-template/styles/emoji.css
+++ b/apps/desktop/src/renderer/src/im-template/styles/emoji.css
@@ -558,6 +558,7 @@
 	display: inline-flex;
 	align-items: center;
 	gap: 9px;
+	box-sizing: border-box;
 	min-width: 120px;
 	max-width: 240px;
 	padding: 8px 13px 8px 9px;
@@ -617,6 +618,12 @@
 	align-items: center;
 	gap: 2px;
 	height: 26px;
+	/* Shrink to fit the strip: with many bars (long clips) the fixed-width
+	   bars would otherwise push past the bubble's max-width. Flexing + clipping
+	   keeps the waveform inside the frame. */
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
 	color: var(--weq-accent-effective, #12a8ff);
 }
 

--- a/apps/desktop/src/renderer/src/im-template/styles/emoji.css
+++ b/apps/desktop/src/renderer/src/im-template/styles/emoji.css
@@ -551,16 +551,28 @@
 	color: var(--weq-accent-effective, #0099ff);
 }
 
-/* Voice: play button + amplitude bars + duration, QQ style. */
+/* Voice: the play strip is a self-contained bubble (play button + amplitude
+   bars + duration). It owns its background so it stays legible regardless of
+   the surrounding message bubble; the 转文字 button lives OUTSIDE it. */
 .qq-media-voice {
 	display: inline-flex;
 	align-items: center;
 	gap: 9px;
-	min-width: 110px;
+	min-width: 120px;
 	max-width: 240px;
-	padding: 2px 4px;
+	padding: 8px 13px 8px 9px;
+	border-radius: 14px;
+	background: var(--weq-chat-bubble-other, #ffffff);
+	border: 1px solid rgba(0, 0, 0, 0.06);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+	color: var(--weq-fg-primary, #1f2937);
 	cursor: pointer;
 	user-select: none;
+	transition: box-shadow 120ms ease;
+}
+
+.qq-media-voice:hover {
+	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.09);
 }
 
 .qq-media-voice-play {
@@ -576,11 +588,36 @@
 	line-height: 1;
 }
 
+/* Voice-changer badge: a small filled star before the waveform marking a
+   变声语音 (voiceChanged) clip. */
+.qq-media-voice-changed {
+	flex: 0 0 auto;
+	color: var(--weq-accent-effective, #12a8ff);
+	fill: currentColor;
+}
+
+/* AI 声聊 badge (element tag 45915): a small pill before the waveform. */
+.qq-media-voice-ai {
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+	flex: 0 0 auto;
+	padding: 1px 5px;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--weq-accent-effective) 16%, transparent);
+	color: var(--weq-accent-effective, #12a8ff);
+	font-size: 10px;
+	font-weight: 600;
+	line-height: 1.4;
+	letter-spacing: 0.3px;
+}
+
 .qq-media-voice-wave {
 	display: flex;
 	align-items: center;
 	gap: 2px;
 	height: 26px;
+	color: var(--weq-accent-effective, #12a8ff);
 }
 
 .qq-media-voice-wave i {
@@ -589,17 +626,62 @@
 	min-height: 3px;
 	border-radius: 1px;
 	background: currentColor;
-	opacity: 0.5;
+	opacity: 0.55;
 }
 
 .qq-media-voice.is-playing .qq-media-voice-wave i {
-	opacity: 0.85;
+	opacity: 0.9;
 }
 
 .qq-media-voice-time {
-	color: #999999;
+	color: #8a9099;
 	font-size: 12px;
+	font-variant-numeric: tabular-nums;
 	white-space: nowrap;
+}
+
+/* ---- my own (sent) voice: solid accent strip, everything reversed to white
+   so the play button, waveform, duration and badges all read clearly (fixes
+   the old blue-on-blue mush). ------------------------------------------------ */
+.message-line.mine .qq-media-voice {
+	background: var(--weq-chat-bubble-mine, #12a8ff);
+	border-color: transparent;
+	box-shadow: 0 1px 3px color-mix(in srgb, var(--weq-accent-effective, #12a8ff) 40%, transparent);
+	color: #ffffff;
+}
+
+.message-line.mine .qq-media-voice:hover {
+	box-shadow: 0 2px 7px color-mix(in srgb, var(--weq-accent-effective, #12a8ff) 48%, transparent);
+}
+
+.message-line.mine .qq-media-voice-play {
+	background: #ffffff;
+	color: var(--weq-accent-effective, #12a8ff);
+}
+
+.message-line.mine .qq-media-voice-wave {
+	color: #ffffff;
+}
+
+.message-line.mine .qq-media-voice-wave i {
+	opacity: 0.72;
+}
+
+.message-line.mine .qq-media-voice.is-playing .qq-media-voice-wave i {
+	opacity: 1;
+}
+
+.message-line.mine .qq-media-voice-time {
+	color: rgba(255, 255, 255, 0.9);
+}
+
+.message-line.mine .qq-media-voice-changed {
+	color: #ffffff;
+}
+
+.message-line.mine .qq-media-voice-ai {
+	background: rgba(255, 255, 255, 0.22);
+	color: #ffffff;
 }
 
 /* Voice transcription: wrapper around the play strip + hover 转文字 button and
@@ -615,34 +697,43 @@
 .qq-voice-row {
 	display: inline-flex;
 	align-items: center;
-	gap: 6px;
+	gap: 7px;
+}
+
+/* On my own (right-aligned) messages the 转文字 button sits to the LEFT of the
+   strip; flip the row so the play strip stays hugging the bubble edge. */
+.message-line.mine .qq-voice-row {
+	flex-direction: row-reverse;
 }
 
 .qq-voice-transcribe-btn {
 	display: inline-flex;
 	align-items: center;
 	gap: 4px;
-	padding: 3px 9px;
+	flex: 0 0 auto;
+	padding: 4px 10px;
 	border: 1px solid color-mix(in srgb, var(--weq-accent-effective) 35%, transparent);
 	border-radius: 999px;
-	background: color-mix(in srgb, var(--weq-accent-effective) 6%, transparent);
+	background: var(--weq-bg-elevated, #ffffff);
 	color: var(--weq-accent-effective, #0099ff);
 	font-size: 12px;
 	line-height: 1;
 	white-space: nowrap;
 	cursor: pointer;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 	opacity: 0;
-	transform: translateX(-2px);
+	transform: scale(0.94);
 	transition: opacity 120ms ease, transform 120ms ease, background 120ms ease;
 }
 
-.qq-voice-wrap:hover .qq-voice-transcribe-btn {
+.qq-voice-wrap:hover .qq-voice-transcribe-btn,
+.qq-voice-transcribe-btn:focus-visible {
 	opacity: 1;
-	transform: translateX(0);
+	transform: scale(1);
 }
 
 .qq-voice-transcribe-btn:hover:not(:disabled) {
-	background: color-mix(in srgb, var(--weq-accent-effective) 14%, transparent);
+	background: color-mix(in srgb, var(--weq-accent-effective) 12%, var(--weq-bg-elevated, #fff));
 }
 
 .qq-voice-transcribe-btn:disabled {
@@ -664,6 +755,13 @@
 	line-height: 1.55;
 	white-space: pre-wrap;
 	word-break: break-word;
+}
+
+/* Keep the transcript reading light-on-... it stays a light bubble even under my
+   own messages (it's a result panel, not part of the accent strip). */
+.message-line.mine .qq-voice-transcript {
+	align-self: flex-end;
+	border-radius: 12px 4px 12px 12px;
 }
 
 .qq-voice-transcript.is-error {

--- a/apps/desktop/src/renderer/src/im-template/styles/sidebar.css
+++ b/apps/desktop/src/renderer/src/im-template/styles/sidebar.css
@@ -499,6 +499,12 @@ html[data-theme="dark"] .contact-cat-count {
 	margin-right: 2px;
 }
 
+.row-redpacket-alert {
+	color: #e8a33d;
+	font-weight: 500;
+	margin-right: 2px;
+}
+
 .row-draft svg {
 	flex: 0 0 auto;
 	color: #ff4b3a;

--- a/apps/desktop/src/renderer/src/im-template/styles/sidebar.css
+++ b/apps/desktop/src/renderer/src/im-template/styles/sidebar.css
@@ -487,6 +487,12 @@ html[data-theme="dark"] .contact-cat-count {
 	font-weight: 500;
 }
 
+.row-specialcare-alert {
+	color: #ff4b3a;
+	font-weight: 500;
+	margin-right: 2px;
+}
+
 .row-draft svg {
 	flex: 0 0 auto;
 	color: #ff4b3a;

--- a/apps/desktop/src/renderer/src/im-template/styles/sidebar.css
+++ b/apps/desktop/src/renderer/src/im-template/styles/sidebar.css
@@ -493,6 +493,12 @@ html[data-theme="dark"] .contact-cat-count {
 	margin-right: 2px;
 }
 
+.row-newfile-alert {
+	color: #2f80ed;
+	font-weight: 500;
+	margin-right: 2px;
+}
+
 .row-draft svg {
 	flex: 0 0 auto;
 	color: #ff4b3a;

--- a/apps/desktop/src/renderer/src/im-template/template/chatMainContent.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/chatMainContent.tsx
@@ -75,6 +75,7 @@ export function ChatMainContent({
 	onOpenGroupAnnouncements,
 	onOpenGroupAnalytics,
 	onOpenBuddyAnalytics,
+	onOpenGroupMember,
 	onAddMessage,
 	onOpenTool,
 	onSelectTool,
@@ -140,6 +141,7 @@ export function ChatMainContent({
 	onOpenGroupAnnouncements?: (conversation: GroupConversation) => void;
 	onOpenGroupAnalytics?: (conversation: GroupConversation) => void;
 	onOpenBuddyAnalytics?: (conversation: DirectConversation) => void;
+	onOpenGroupMember?: (member: any, anchor: { x: number; y: number }) => void;
 	onAddMessage?: (conversation: Conversation) => void;
 	onOpenTool?: (item: ToolPaneItem) => void;
 	onSelectTool?: (item: ToolPaneItem) => void;
@@ -214,6 +216,7 @@ export function ChatMainContent({
 			onOpenGroupAnnouncements={onOpenGroupAnnouncements}
 			onOpenGroupAnalytics={onOpenGroupAnalytics}
 			onOpenBuddyAnalytics={onOpenBuddyAnalytics}
+			onOpenGroupMember={onOpenGroupMember}
 			onAddMessage={onAddMessage}
 		/>
 	);

--- a/apps/desktop/src/renderer/src/im-template/template/chatMainContent.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/chatMainContent.tsx
@@ -71,12 +71,16 @@ export function ChatMainContent({
 	onDraftClear,
 	onBackConversation,
 	onEditRaw,
+	onDeleteMessage,
+	onHardDeleteMessage,
 	onOpenGroupAlbums,
 	onOpenGroupAnnouncements,
 	onOpenGroupAnalytics,
 	onOpenBuddyAnalytics,
 	onOpenGroupMember,
 	onAddMessage,
+	onViewDeleted,
+	hiddenReloadKey,
 	onOpenTool,
 	onSelectTool,
 }: {
@@ -137,12 +141,17 @@ export function ChatMainContent({
 	onDraftClear: (conversationId: string) => void;
 	onBackConversation: () => void;
 	onEditRaw?: (message: Message) => void;
+	onDeleteMessage?: (message: Message) => void | Promise<void>;
+	onHardDeleteMessage?: (message: Message) => void | Promise<void>;
 	onOpenGroupAlbums?: (conversation: GroupConversation) => void;
 	onOpenGroupAnnouncements?: (conversation: GroupConversation) => void;
 	onOpenGroupAnalytics?: (conversation: GroupConversation) => void;
 	onOpenBuddyAnalytics?: (conversation: DirectConversation) => void;
 	onOpenGroupMember?: (member: any, anchor: { x: number; y: number }) => void;
 	onAddMessage?: (conversation: Conversation) => void;
+	onViewDeleted?: (conversation: Conversation) => void;
+	/** Bumped after a restore so ChatPane re-reads its local hidden-message set. */
+	hiddenReloadKey?: number;
 	onOpenTool?: (item: ToolPaneItem) => void;
 	onSelectTool?: (item: ToolPaneItem) => void;
 }) {
@@ -212,12 +221,16 @@ export function ChatMainContent({
 			onDraftClear={onDraftClear}
 			onBack={onBackConversation}
 			onEditRaw={onEditRaw}
+			onDeleteMessage={onDeleteMessage}
+			onHardDeleteMessage={onHardDeleteMessage}
 			onOpenGroupAlbums={onOpenGroupAlbums}
 			onOpenGroupAnnouncements={onOpenGroupAnnouncements}
 			onOpenGroupAnalytics={onOpenGroupAnalytics}
 			onOpenBuddyAnalytics={onOpenBuddyAnalytics}
 			onOpenGroupMember={onOpenGroupMember}
 			onAddMessage={onAddMessage}
+			onViewDeleted={onViewDeleted}
+			hiddenReloadKey={hiddenReloadKey}
 		/>
 	);
 }

--- a/apps/desktop/src/renderer/src/im-template/template/chatPane.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/chatPane.tsx
@@ -1430,6 +1430,11 @@ export function ChatPane({
 									onContextMenu={openMessageMenu}
 									onLongPress={openMobileMessageMenu}
 									onAction={onMessageAction}
+									onAvatarClick={
+										conversation.type === "group" && onOpenGroupMember
+											? onOpenGroupMember
+											: undefined
+									}
 								/>
 							</Fragment>
 						);

--- a/apps/desktop/src/renderer/src/im-template/template/chatPane.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/chatPane.tsx
@@ -204,6 +204,7 @@ export function ChatPane({
 	onOpenGroupAnnouncements,
 	onOpenGroupAnalytics,
 	onOpenBuddyAnalytics,
+	onOpenGroupMember,
 	onAddMessage,
 }: {
 	user: User;
@@ -233,6 +234,7 @@ export function ChatPane({
 	onOpenGroupAnnouncements?: (conversation: Extract<Conversation, { type: "group" }>) => void;
 	onOpenGroupAnalytics?: (conversation: Extract<Conversation, { type: "group" }>) => void;
 	onOpenBuddyAnalytics?: (conversation: Extract<Conversation, { type: "direct" }>) => void;
+	onOpenGroupMember?: (member: any, anchor: { x: number; y: number }) => void;
 	onAddMessage?: (conversation: Conversation) => void;
 }) {
 	// 复用 replyJump 的跳转能力（含翻页/重建窗口），供群精华消息跳转使用。
@@ -1478,6 +1480,7 @@ export function ChatPane({
 						<GroupInfoPanel
 							conversation={conversation}
 							onOpenDetail={openGroupInfoDetail}
+							onOpenMember={onOpenGroupMember}
 							onLoadMoreMembers={onLoadMoreGroupMembers}
 							loadingMoreMembers={groupMembersLoading}
 						/>

--- a/apps/desktop/src/renderer/src/im-template/template/chatPane.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/chatPane.tsx
@@ -7,6 +7,7 @@ import {
 	ChevronRight,
 	ChevronsUp,
 	CirclePlus,
+	Trash2,
 	FileText,
 	Images,
 	MessageSquareText,
@@ -200,12 +201,16 @@ export function ChatPane({
 	onDraftClear,
 	onBack,
 	onEditRaw,
+	onDeleteMessage,
+	onHardDeleteMessage,
 	onOpenGroupAlbums,
 	onOpenGroupAnnouncements,
 	onOpenGroupAnalytics,
 	onOpenBuddyAnalytics,
 	onOpenGroupMember,
 	onAddMessage,
+	onViewDeleted,
+	hiddenReloadKey,
 }: {
 	user: User;
 	conversation: Conversation | undefined;
@@ -230,12 +235,17 @@ export function ChatPane({
 	onDraftClear: (conversationId: string) => void;
 	onBack: () => void;
 	onEditRaw?: (message: Message) => void;
+	onDeleteMessage?: (message: Message) => void | Promise<void>;
+	onHardDeleteMessage?: (message: Message) => void | Promise<void>;
 	onOpenGroupAlbums?: (conversation: Extract<Conversation, { type: "group" }>) => void;
 	onOpenGroupAnnouncements?: (conversation: Extract<Conversation, { type: "group" }>) => void;
 	onOpenGroupAnalytics?: (conversation: Extract<Conversation, { type: "group" }>) => void;
 	onOpenBuddyAnalytics?: (conversation: Extract<Conversation, { type: "direct" }>) => void;
 	onOpenGroupMember?: (member: any, anchor: { x: number; y: number }) => void;
 	onAddMessage?: (conversation: Conversation) => void;
+	onViewDeleted?: (conversation: Conversation) => void;
+	/** Bumped by the parent after a restore so this pane re-reads hidden ids. */
+	hiddenReloadKey?: number;
 }) {
 	// 复用 replyJump 的跳转能力（含翻页/重建窗口），供群精华消息跳转使用。
 	const jumpToSeq = useContext(ReplyJumpContext);
@@ -425,6 +435,14 @@ export function ChatPane({
 		setHiddenMessageIds(loadHiddenMessageIds(conversation?.id));
 	}, [conversation?.id]);
 
+	// Re-read the local hidden set when the parent signals a restore (bumping
+	// `hiddenReloadKey`), so a message un-hidden from the deleted panel reappears
+	// in the live chat without touching the rest of the conversation reset above.
+	useEffect(() => {
+		if (!hiddenReloadKey) return;
+		setHiddenMessageIds(loadHiddenMessageIds(conversation?.id));
+	}, [hiddenReloadKey, conversation?.id]);
+
 	useEffect(() => {
 		const editor = composerEditorRef.current;
 		setBody(draft);
@@ -475,6 +493,68 @@ export function ChatPane({
 			window.removeEventListener("resize", closeMenu);
 		};
 	}, [contextMenu]);
+
+	// Keep the desktop context menu glued to its message as the list scrolls,
+	// instead of floating in place. Dismisses once the message leaves the list
+	// viewport. Mobile menus (long-press sheet) keep their fixed placement.
+	useEffect(() => {
+		if (!contextMenu || contextMenu.variant === "mobile") {
+			return;
+		}
+		const scroll = messageScrollRef.current;
+		if (!scroll) {
+			return;
+		}
+
+		let frame = 0;
+		function reposition() {
+			if (frame) {
+				return;
+			}
+			frame = window.requestAnimationFrame(() => {
+				frame = 0;
+				setContextMenu((current) => {
+					if (!current || current.variant === "mobile") {
+						return current;
+					}
+					const container = messageScrollRef.current;
+					if (!container) {
+						return current;
+					}
+					const idSelector = current.message.id.replace(/["\\]/g, "\\$&");
+					const el = container.querySelector<HTMLElement>(
+						`[data-message-id="${idSelector}"]`,
+					);
+					if (!el) {
+						return current;
+					}
+					const rect = el.getBoundingClientRect();
+					const bounds = container.getBoundingClientRect();
+					// Message scrolled out of the list viewport → dismiss the menu.
+					if (rect.bottom < bounds.top || rect.top > bounds.bottom) {
+						return null;
+					}
+					const x = Math.min(
+						rect.left + (current.anchorOffsetX ?? 0),
+						window.innerWidth - 126,
+					);
+					const y = Math.min(
+						Math.max(rect.top + (current.anchorOffsetY ?? 0), 8),
+						window.innerHeight - 84,
+					);
+					return { ...current, x, y };
+				});
+			});
+		}
+
+		scroll.addEventListener("scroll", reposition, { passive: true });
+		return () => {
+			scroll.removeEventListener("scroll", reposition);
+			if (frame) {
+				window.cancelAnimationFrame(frame);
+			}
+		};
+	}, [contextMenu?.message.id, contextMenu?.variant]);
 
 	useEffect(() => {
 		if (!emojiOpen) {
@@ -870,12 +950,20 @@ export function ChatPane({
 		}
 		event.preventDefault();
 		window.getSelection()?.removeAllRanges();
+		// Record where the click landed inside the message row so the menu can
+		// track that row as the list scrolls (see the reposition effect below).
+		const anchorEl = (event.currentTarget as HTMLElement).closest?.(
+			"[data-message-id]",
+		) as HTMLElement | null;
+		const anchorRect = anchorEl?.getBoundingClientRect();
 		setContextMenu({
 			message,
 			downloadUrl: getMessageDownloadUrl(message),
 			x: Math.min(event.clientX, window.innerWidth - 126),
 			y: Math.min(event.clientY, window.innerHeight - 84),
 			variant: "desktop",
+			anchorOffsetX: anchorRect ? event.clientX - anchorRect.left : undefined,
+			anchorOffsetY: anchorRect ? event.clientY - anchorRect.top : undefined,
 		});
 	}
 
@@ -1135,7 +1223,10 @@ export function ChatPane({
 
 	async function copyMessage(message: Message) {
 		const selectedText = window.getSelection()?.toString().trim();
-		await copyTextToClipboard(selectedText || message.body);
+		// Non-copyable messages (images/files/cards) render an empty body — fall
+		// back to a `msgid=xxx` reference so there's always something on the clipboard.
+		const body = message.body?.trim() ? message.body : `msgid=${message.id}`;
+		await copyTextToClipboard(selectedText || body);
 		setContextMenu(null);
 	}
 
@@ -1144,6 +1235,7 @@ export function ChatPane({
 			return;
 		}
 
+		// Hide immediately for instant feedback...
 		setHiddenMessageIds((current) => {
 			const next = new Set(current);
 			next.add(message.id);
@@ -1151,6 +1243,31 @@ export function ChatPane({
 			return next;
 		});
 		setContextMenu(null);
+		// ...and reversibly soft-delete the underlying DB row (hidden, restorable).
+		void onDeleteMessage?.(message);
+	}
+
+	// Hard-delete: physically drops the DB row (no restore). Same instant-hide
+	// UX as soft-delete — no confirmation prompt.
+	function hardDeleteMessageLocally(message: Message) {
+		if (!conversation) {
+			return;
+		}
+		setHiddenMessageIds((current) => {
+			const next = new Set(current);
+			next.add(message.id);
+			saveHiddenMessageIds(conversation.id, next);
+			return next;
+		});
+		setContextMenu(null);
+		void onHardDeleteMessage?.(message);
+	}
+
+	function editMessageRaw(message: Message) {
+		// Close the menu before the editor lightbox opens so it doesn't linger
+		// on top of / behind the modal.
+		setContextMenu(null);
+		onEditRaw?.(message);
 	}
 
 	function requestClearConversationMessages() {
@@ -1276,6 +1393,17 @@ export function ChatPane({
 							onClick={() => onAddMessage(conversation)}
 						>
 							<CirclePlus size={18} />
+						</button>
+					) : null}
+					{onViewDeleted &&
+					(conversation.type === "group" || conversation.type === "direct") ? (
+						<button
+							className={cn("icon-button", "group-header-info-action")}
+							type="button"
+							title="查看删除消息"
+							onClick={() => onViewDeleted(conversation)}
+						>
+							<Trash2 size={18} />
 						</button>
 					) : null}
 					{conversation.type === "group" ? (
@@ -1717,7 +1845,8 @@ export function ChatPane({
 					onCopy={copyMessage}
 					onDownloadImage={downloadMessageImage}
 					onDeleteLocal={deleteMessageLocally}
-					onEditRaw={onEditRaw}
+					onHardDelete={onHardDeleteMessage ? hardDeleteMessageLocally : undefined}
+					onEditRaw={onEditRaw ? editMessageRaw : undefined}
 				/>
 			) : null}
 			{groupInfoDetail && conversation.type === "group" ? (

--- a/apps/desktop/src/renderer/src/im-template/template/conversationLists.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/conversationLists.tsx
@@ -71,6 +71,8 @@ export function ConversationList({
 					unreadCount > 0 && highlightKinds.has("specialCare");
 				// 新文件：内容类提示（非「找你」告警），行首挂蓝色标记。
 				const showNewFile = unreadCount > 0 && highlightKinds.has("newFile");
+				// QQ红包：内容类提示，行首挂金色标记。
+				const showRedPacket = unreadCount > 0 && highlightKinds.has("redPacket");
 				// 免打扰：会话自带的 DB 值（41220）打底，本地手动偏好覆盖 ——
 				// 与 shellController.countVisibleUnreadConversations 的 merge 顺序保持一致。
 				const muted = Boolean({
@@ -125,6 +127,9 @@ export function ConversationList({
 										) : null}
 										{showNewFile ? (
 											<span className={cn("row-newfile-alert")}>[新文件]</span>
+										) : null}
+										{showRedPacket ? (
+											<span className={cn("row-redpacket-alert")}>[红包]</span>
 										) : null}
 										{preview.text}
 									</span>

--- a/apps/desktop/src/renderer/src/im-template/template/conversationLists.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/conversationLists.tsx
@@ -58,6 +58,14 @@ export function ConversationList({
 				const hasDraft = !active && Boolean(drafts[conversation.id]?.trim());
 				const preview = conversationLastMessage(conversation, user);
 				const showMentionAlert = unreadCount > 0 && preview.mentionsMe;
+				// 特别关心：会话存在特别关心好友未读时，行首挂红色标记。
+				const showSpecialCare = unreadCount > 0 && Boolean(conversation.specialCare);
+				// 免打扰：会话自带的 DB 值（41220）打底，本地手动偏好覆盖 ——
+				// 与 shellController.countVisibleUnreadConversations 的 merge 顺序保持一致。
+				const muted = Boolean({
+					...conversation.preference,
+					...preferences[conversation.id],
+				}.muted);
 
 				return (
 					<button
@@ -95,13 +103,16 @@ export function ConversationList({
 									</span>
 								) : (
 									<span className={cn("row-message-preview")}>
+										{showSpecialCare ? (
+											<span className={cn("row-specialcare-alert")}>[特别关心]</span>
+										) : null}
 										{showMentionAlert ? (
 											<span className={cn("row-mention-alert")}>[有人@我]</span>
 										) : null}
 										{preview.text}
 									</span>
 								)}
-								{!unreadCount && preferences[conversation.id]?.muted ? (
+								{!unreadCount && muted ? (
 									<BellOff className={cn("row-muted")} size={15} />
 								) : null}
 							</span>
@@ -109,11 +120,7 @@ export function ConversationList({
 						<span className={cn("row-meta")}>
 							<span>{formatConversationTime(conversation.updatedAt)}</span>
 							{unreadCount ? (
-								<span
-									className={cn(
-										unreadClass(Boolean(preferences[conversation.id]?.muted)),
-									)}
-								>
+								<span className={cn(unreadClass(muted))}>
 									{formatBadgeCount(unreadCount)}
 								</span>
 							) : null}

--- a/apps/desktop/src/renderer/src/im-template/template/conversationLists.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/conversationLists.tsx
@@ -57,9 +57,20 @@ export function ConversationList({
 				const unreadCount = conversation.unreadCount ?? 0;
 				const hasDraft = !active && Boolean(drafts[conversation.id]?.trim());
 				const preview = conversationLastMessage(conversation, user);
-				const showMentionAlert = unreadCount > 0 && preview.mentionsMe;
+				// 提醒高亮：来自 48902 的权威标记（特别关心 / @我 …）。
+				const highlightKinds = new Set(
+					(conversation.highlights ?? []).map((h) => h.kind),
+				);
+				// @我：优先用 48902 权威标记，回退到本地对消息正文的启发式解析。
+				const showMentionAlert =
+					unreadCount > 0 && (highlightKinds.has("atMe") || preview.mentionsMe);
+				// @全体成员：同属「找你」红色告警类。
+				const showAtAll = unreadCount > 0 && highlightKinds.has("atAll");
 				// 特别关心：会话存在特别关心好友未读时，行首挂红色标记。
-				const showSpecialCare = unreadCount > 0 && Boolean(conversation.specialCare);
+				const showSpecialCare =
+					unreadCount > 0 && highlightKinds.has("specialCare");
+				// 新文件：内容类提示（非「找你」告警），行首挂蓝色标记。
+				const showNewFile = unreadCount > 0 && highlightKinds.has("newFile");
 				// 免打扰：会话自带的 DB 值（41220）打底，本地手动偏好覆盖 ——
 				// 与 shellController.countVisibleUnreadConversations 的 merge 顺序保持一致。
 				const muted = Boolean({
@@ -108,6 +119,12 @@ export function ConversationList({
 										) : null}
 										{showMentionAlert ? (
 											<span className={cn("row-mention-alert")}>[有人@我]</span>
+										) : null}
+										{showAtAll ? (
+											<span className={cn("row-mention-alert")}>[@全体]</span>
+										) : null}
+										{showNewFile ? (
+											<span className={cn("row-newfile-alert")}>[新文件]</span>
 										) : null}
 										{preview.text}
 									</span>

--- a/apps/desktop/src/renderer/src/im-template/template/groupInfoPanel.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/groupInfoPanel.tsx
@@ -13,11 +13,16 @@ export function GroupInfoPanel({
 	onLoadMoreMembers,
 	loadingMoreMembers,
 	onOpenDetail,
+	onOpenMember,
 }: {
 	conversation: GroupConversationView;
 	onLoadMoreMembers?: () => void;
 	loadingMoreMembers?: boolean;
 	onOpenDetail?: (detail: GroupInfoDetail) => void;
+	onOpenMember?: (
+		member: GroupConversationView["members"][number],
+		anchor: { x: number; y: number },
+	) => void;
 }) {
 	const memberListRef = useRef<HTMLDivElement | null>(null);
 	const group = conversation.group;
@@ -94,10 +99,34 @@ export function GroupInfoPanel({
 						<div
 							className={cn(
 								"group-info-member-row",
+								onOpenMember && "is-clickable",
 								member.role === "owner" && "is-owner",
 								member.role === "admin" && "is-admin",
 							)}
 							key={member.id}
+							role={onOpenMember ? "button" : undefined}
+							tabIndex={onOpenMember ? 0 : undefined}
+							title={onOpenMember ? "查看资料" : undefined}
+							onClick={
+								onOpenMember
+									? (event) =>
+											onOpenMember(member, { x: event.clientX, y: event.clientY })
+									: undefined
+							}
+							onKeyDown={
+								onOpenMember
+									? (event) => {
+											if (event.key === "Enter" || event.key === " ") {
+												event.preventDefault();
+												const rect = event.currentTarget.getBoundingClientRect();
+												onOpenMember(member, {
+													x: rect.left + rect.width / 2,
+													y: rect.bottom,
+												});
+											}
+										}
+									: undefined
+							}
 						>
 							<div className="member-avatar-wrap">
 								<Avatar

--- a/apps/desktop/src/renderer/src/im-template/template/messageBubble.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/messageBubble.tsx
@@ -30,6 +30,7 @@ export function MessageBubble({
 	onContextMenu,
 	onLongPress,
 	onAction,
+	onAvatarClick,
 }: {
 	message: Message;
 	conversation: Conversation;
@@ -45,6 +46,7 @@ export function MessageBubble({
 	onContextMenu: (event: ReactMouseEvent, message: Message) => void;
 	onLongPress: (point: { x: number; y: number }, message: Message) => void;
 	onAction?: (message: Message, action: MessageAction) => void | Promise<void>;
+	onAvatarClick?: (sender: User, anchor: { x: number; y: number }) => void;
 }) {
 	const longPressTimerRef = useRef<number | null>(null);
 	const longPressPointRef = useRef<{ x: number; y: number } | null>(null);
@@ -130,11 +132,29 @@ export function MessageBubble({
 			data-message-id={message.id}
 		>
 			{!mine ? (
-				<Avatar
-					name={senderName}
-					avatarUrl={senderAvatarUrl}
-					seed={senderSeed}
-				/>
+				onAvatarClick ? (
+					<button
+						type="button"
+						className={cn("message-avatar-button")}
+						title="查看资料"
+						aria-label={`查看 ${senderName} 的资料`}
+						onClick={(event) =>
+							onAvatarClick(sender, { x: event.clientX, y: event.clientY })
+						}
+					>
+						<Avatar
+							name={senderName}
+							avatarUrl={senderAvatarUrl}
+							seed={senderSeed}
+						/>
+					</button>
+				) : (
+					<Avatar
+						name={senderName}
+						avatarUrl={senderAvatarUrl}
+						seed={senderSeed}
+					/>
+				)
 			) : null}
 			<div
 				ref={bubbleRef}

--- a/apps/desktop/src/renderer/src/im-template/template/messageBubble.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/messageBubble.tsx
@@ -154,15 +154,26 @@ export function MessageBubble({
 				{showSenderName ? (
 					<span className={cn("message-name")}>
 						{senderName}
-						{(sender as any).customTitle || (sender as any).levelName ? (
-							<small className={cn(
-								"member-badge", 
-								(sender as any).role,
-								(sender as any).levelBracket > 0 ? `level-${(sender as any).levelBracket}` : ""
-							)}>
-								{(sender as any).memberLevel != null ? `Lv${(sender as any).memberLevel} · ` : ''}{(sender as any).customTitle || (sender as any).levelName}
-							</small>
-						) : null}
+						{(() => {
+							const role = (sender as any).role;
+							const isRoleBadge = role === "owner" || role === "admin";
+							// 群头衔优先级：群主/管理员 > 自定义头衔/群等级
+							const badgeText = isRoleBadge
+								? (role === "owner" ? "群主" : "管理员")
+								: ((sender as any).customTitle || (sender as any).levelName);
+							if (!badgeText) return null;
+							const levelBracket = (sender as any).levelBracket;
+							const memberLevel = (sender as any).memberLevel;
+							return (
+								<small className={cn(
+									"member-badge",
+									isRoleBadge ? role : "",
+									!isRoleBadge && levelBracket > 0 ? `level-${levelBracket}` : ""
+								)}>
+									{!isRoleBadge && memberLevel != null ? `Lv${memberLevel} · ` : ''}{badgeText}
+								</small>
+							);
+						})()}
 						{senderKind === "bot" ? (
 							<small
 								className={cn("bot-badge")}

--- a/apps/desktop/src/renderer/src/im-template/template/messageContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/messageContextMenu.tsx
@@ -1,4 +1,4 @@
-﻿import { Copy, Download, Trash2, Edit3 } from "lucide-react";
+﻿import { Copy, Download, Trash2, Trash, Edit3 } from "lucide-react";
 import type { Message } from "./types";
 import { cn } from "./classNames";
 
@@ -8,6 +8,12 @@ export type MessageContextMenuState = {
 	y: number;
 	downloadUrl?: string;
 	variant?: "desktop" | "mobile";
+	/**
+	 * Click point offset within the anchored message row at open time. Used to
+	 * keep the desktop menu glued to its message while the list scrolls.
+	 */
+	anchorOffsetX?: number;
+	anchorOffsetY?: number;
 };
 
 export function MessageContextMenu({
@@ -15,12 +21,14 @@ export function MessageContextMenu({
 	onCopy,
 	onDownloadImage,
 	onDeleteLocal,
+	onHardDelete,
 	onEditRaw,
 }: {
 	state: MessageContextMenuState;
 	onCopy: (message: Message) => void | Promise<void>;
 	onDownloadImage?: (url: string, message: Message) => void;
 	onDeleteLocal: (message: Message) => void;
+	onHardDelete?: (message: Message) => void;
 	onEditRaw?: (message: Message) => void;
 }) {
 	return (
@@ -65,8 +73,18 @@ export function MessageContextMenu({
 			) : null}
 			<button type="button" onClick={() => onDeleteLocal(state.message)}>
 				<Trash2 size={17} />
-				<span>删除</span>
+				<span>软删除（实验）</span>
 			</button>
+			{onHardDelete ? (
+				<button
+					type="button"
+					className="is-danger"
+					onClick={() => onHardDelete(state.message)}
+				>
+					<Trash size={17} />
+					<span>删除</span>
+				</button>
+			) : null}
 		</div>
 	);
 }

--- a/apps/desktop/src/renderer/src/im-template/template/profilePanes.tsx
+++ b/apps/desktop/src/renderer/src/im-template/template/profilePanes.tsx
@@ -52,12 +52,12 @@ const RELATION_META: Record<
 
 const DEFAULT_RELATION = { label: "游戏搭子", Icon: Gamepad2, intimate: false };
 
-function relationMeta(id: number) {
+export function relationMeta(id: number) {
 	return RELATION_META[id] ?? DEFAULT_RELATION;
 }
 
 /** 由出生月日推算星座名（标准日期分界）。缺月或日时返回 null。 */
-function constellationOf(month?: number, day?: number) {
+export function constellationOf(month?: number, day?: number) {
 	if (!month || !day) {
 		return null;
 	}
@@ -80,7 +80,7 @@ function constellationOf(month?: number, day?: number) {
 	return entry[1];
 }
 
-function birthdayText(year?: number, month?: number, day?: number) {
+export function birthdayText(year?: number, month?: number, day?: number) {
 	if (!month || !day) {
 		return null;
 	}
@@ -504,7 +504,7 @@ export function GroupProfileDialog({
 	);
 }
 
-function ProfileRow({
+export function ProfileRow({
 	icon,
 	label,
 	value,
@@ -543,7 +543,7 @@ function ProfileRow({
 	);
 }
 
-function genderLabel(value?: number) {
+export function genderLabel(value?: number) {
 	if (value === 1) {
 		return "男";
 	}

--- a/apps/desktop/src/renderer/src/im-template/template/types.ts
+++ b/apps/desktop/src/renderer/src/im-template/template/types.ts
@@ -43,7 +43,13 @@ export type GroupMember = User & {
 	levelName?: string | null;
 };
 
-export type ConversationHighlightKind = "atMe" | "atAll" | "specialCare" | "newFile" | "unknown";
+export type ConversationHighlightKind =
+	| "atMe"
+	| "atAll"
+	| "specialCare"
+	| "newFile"
+	| "redPacket"
+	| "unknown";
 
 export type ConversationHighlight = {
 	kind: ConversationHighlightKind;

--- a/apps/desktop/src/renderer/src/im-template/template/types.ts
+++ b/apps/desktop/src/renderer/src/im-template/template/types.ts
@@ -48,6 +48,11 @@ type ConversationBase = {
 	updatedAt: string;
 	preference?: ConversationPreference;
 	unreadCount?: number;
+	/**
+	 * 特别关心标记：该会话存在特别关心好友发来的未读时置位，来自
+	 * msg_unread_info_table 的 48902 高亮扩展。msgSeq 保留但不展示。
+	 */
+	specialCare?: { senderUid: string; msgSeq: string } | null;
 	lastMessage: {
 		id: string;
 		senderId: string | null;

--- a/apps/desktop/src/renderer/src/im-template/template/types.ts
+++ b/apps/desktop/src/renderer/src/im-template/template/types.ts
@@ -43,16 +43,25 @@ export type GroupMember = User & {
 	levelName?: string | null;
 };
 
+export type ConversationHighlightKind = "atMe" | "atAll" | "specialCare" | "newFile" | "unknown";
+
+export type ConversationHighlight = {
+	kind: ConversationHighlightKind;
+	rawKind: number;
+	senderUid: string;
+	msgSeq: string;
+};
+
 type ConversationBase = {
 	id: string;
 	updatedAt: string;
 	preference?: ConversationPreference;
 	unreadCount?: number;
 	/**
-	 * 特别关心标记：该会话存在特别关心好友发来的未读时置位，来自
-	 * msg_unread_info_table 的 48902 高亮扩展。msgSeq 保留但不展示。
+	 * 提醒高亮标记（特别关心 / @我 / …）：该会话存在对应类别的未读时置位，
+	 * 来自 msg_unread_info_table 的 48902 高亮扩展。msgSeq 保留但不展示。
 	 */
-	specialCare?: { senderUid: string; msgSeq: string } | null;
+	highlights?: ConversationHighlight[] | null;
 	lastMessage: {
 		id: string;
 		senderId: string | null;

--- a/apps/desktop/src/renderer/src/lib/avatarCache.ts
+++ b/apps/desktop/src/renderer/src/lib/avatarCache.ts
@@ -6,15 +6,39 @@
  */
 
 const SCHEME = 'weq-avatar';
+const MEDIA_SCHEME = 'weq-media';
 
 /**
- * Wrap an upstream avatar URL so it's served from the disk cache. Returns
- * `null`/local/already-wrapped/data URLs untouched (nothing to cache).
+ * Build the local-first avatar URL: the main process resolves the peer's cached
+ * `nt_data/avatar` file (via the uid hash formula) and only hits the CDN — the
+ * original `fb` url — on a miss. `v=big` asks for the original; the resolver
+ * falls back to the thumbnail when that's all QQ cached.
+ */
+function localFirst(params: Record<string, string>, fb: string): string {
+  const q = new URLSearchParams({ ...params, v: 'big', fb });
+  return `${MEDIA_SCHEME}://avatar?${q.toString()}`;
+}
+
+/**
+ * Wrap an upstream avatar URL so it's served from a disk cache. QQ avatars
+ * (user / group) are routed local-first through `weq-media://avatar` — QQ
+ * already cached them under `nt_data/avatar`, so we serve those bytes offline
+ * and instantly, falling back to the CDN when absent. Other remote avatars go
+ * through the `weq-avatar://` URL cache. `null`/local/data URLs are untouched.
  */
 export function cachedAvatarUrl(src: string | null | undefined): string | null {
   if (!src) return null;
-  // Only remote http(s) avatars go through the cache; leave data:, blob:,
+  // Only remote http(s) avatars go through a cache; leave data:, blob:,
   // weq-asset:, and anything already wrapped alone.
   if (!/^https?:\/\//i.test(src)) return src;
+
+  // User avatar endpoint: …qlogo.cn/g?…&nk=<uin>… (thirdqq / q / q1 / q2).
+  const userNk = src.match(/^https?:\/\/[^/]*qlogo\.cn\/[^?]*\?[^#]*\bnk=(\d+)/i);
+  if (userNk) return localFirst({ scope: 'user', uin: userNk[1]! }, src);
+  // Group avatar endpoint: …p.qlogo.cn/gh/<code>/<code>/<size> (code == uid).
+  const groupGh = src.match(/^https?:\/\/[^/]*qlogo\.cn\/gh\/(\d+)\//i);
+  if (groupGh) return localFirst({ scope: 'group', uid: groupGh[1]! }, src);
+
+  // Non-QQ remote avatar (e.g. GitHub in demo/agentlab): plain URL disk cache.
   return `${SCHEME}://fetch?src=${encodeURIComponent(src)}`;
 }

--- a/apps/desktop/src/renderer/src/styles/cache.css
+++ b/apps/desktop/src/renderer/src/styles/cache.css
@@ -1028,6 +1028,324 @@
   color: #8a94a4;
 }
 
+/* “算路径”工具按钮：推到 tab 行最右。 */
+.weq-cache-avatar-tool {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border: 1px solid color-mix(in srgb, var(--weq-accent-effective) 30%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--weq-accent-effective) 8%, transparent);
+  color: var(--weq-accent-effective);
+  font-size: 11.5px;
+  cursor: pointer;
+  transition: background-color 130ms ease, border-color 130ms ease;
+}
+
+.weq-cache-avatar-tool svg {
+  width: 13px;
+  height: 13px;
+}
+
+.weq-cache-avatar-tool:hover {
+  background: color-mix(in srgb, var(--weq-accent-effective) 16%, transparent);
+  border-color: color-mix(in srgb, var(--weq-accent-effective) 50%, transparent);
+}
+
+/* ===== 头像缓存路径计算器（弹窗） ===== */
+.weq-avpath {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 15px 17px 17px;
+}
+
+.weq-avpath-head {
+  display: flex;
+  align-items: center;
+}
+
+.weq-avpath-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #283342;
+}
+
+.weq-avpath-head .weq-dialog-x {
+  margin-left: auto;
+}
+
+.weq-avpath-form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.weq-avpath-seg {
+  display: inline-flex;
+  padding: 2px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 9px;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.weq-avpath-segbtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 9px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: #6b7480;
+  font-size: 11.5px;
+  cursor: pointer;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.weq-avpath-segbtn svg {
+  width: 12px;
+  height: 12px;
+}
+
+.weq-avpath-segbtn.is-on {
+  background: var(--weq-accent-effective);
+  color: #fff;
+  font-weight: 600;
+}
+
+.weq-avpath-input {
+  flex: 1;
+  min-width: 0;
+  padding: 5px 10px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 8px;
+  background: #fff;
+  font-size: 12px;
+  color: #283342;
+  outline: none;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.weq-avpath-input:focus {
+  border-color: color-mix(in srgb, var(--weq-accent-effective) 55%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--weq-accent-effective) 14%, transparent);
+}
+
+/* 紧凑版“计算”按钮：覆盖 weq-action-primary 的尺寸。 */
+.weq-avpath-go {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 11px;
+  font-size: 11.5px;
+  white-space: nowrap;
+}
+
+.weq-avpath-go svg {
+  width: 12px;
+  height: 12px;
+}
+
+/* 算法依据块 */
+.weq-avpath-algo {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--weq-accent-effective) 20%, transparent);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--weq-accent-effective) 6%, transparent);
+}
+
+.weq-avpath-algo-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--weq-accent-effective);
+}
+
+.weq-avpath-algo-code {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 11px;
+  color: #34404e;
+  word-break: break-all;
+}
+
+.weq-avpath-algo-note {
+  margin: 1px 0 0;
+  font-size: 10.5px;
+  line-height: 1.5;
+  color: #6b7480;
+}
+
+.weq-avpath-algo-note b {
+  color: #34404e;
+}
+
+.weq-avpath-error {
+  padding: 8px 11px;
+  border-radius: 8px;
+  background: color-mix(in srgb, #ef4444 10%, transparent);
+  color: #b91c1c;
+  font-size: 11.5px;
+  line-height: 1.5;
+}
+
+/* 结果区 */
+.weq-avpath-result {
+  display: flex;
+  gap: 14px;
+}
+
+.weq-avpath-preview {
+  flex: none;
+  width: 78px;
+  height: 78px;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 11px;
+  background: rgba(0, 0, 0, 0.03);
+  overflow: hidden;
+}
+
+.weq-avpath-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.weq-avpath-preview-empty {
+  font-size: 10.5px;
+  color: #98a1ac;
+}
+
+.weq-avpath-fields {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.weq-avpath-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.weq-avpath-field-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: #8a94a4;
+}
+
+.weq-avpath-field-val {
+  font-size: 11.5px;
+  color: #283342;
+}
+
+.weq-avpath-mono {
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  word-break: break-all;
+}
+
+.weq-avpath-hash {
+  color: var(--weq-accent-effective);
+}
+
+.weq-avpath-nick {
+  font-style: normal;
+  color: #8a94a4;
+}
+
+.weq-avpath-badge {
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.weq-avpath-badge.is-on {
+  color: #15803d;
+  background: color-mix(in srgb, #22c55e 16%, transparent);
+}
+
+.weq-avpath-badge.is-off {
+  color: #98a1ac;
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.weq-avpath-pathrow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.weq-avpath-path {
+  flex: 1;
+  min-width: 0;
+  font-size: 11px;
+  color: #4a5462;
+}
+
+.weq-avpath-copy {
+  flex: none;
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 6px;
+  background: #fff;
+  color: #8a94a4;
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+.weq-avpath-copy:hover {
+  color: var(--weq-accent-effective);
+  border-color: color-mix(in srgb, var(--weq-accent-effective) 40%, transparent);
+}
+
+/* 暗色适配 */
+html[data-theme="dark"] .weq-avpath-title,
+html[data-theme="dark"] .weq-avpath-algo-code,
+html[data-theme="dark"] .weq-avpath-algo-note b,
+html[data-theme="dark"] .weq-avpath-field-val {
+  color: #e6ebf2;
+}
+
+html[data-theme="dark"] .weq-avpath-input {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.14);
+  color: #e6ebf2;
+}
+
+html[data-theme="dark"] .weq-avpath-preview,
+html[data-theme="dark"] .weq-avpath-seg {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+html[data-theme="dark"] .weq-avpath-copy {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+html[data-theme="dark"] .weq-avpath-path {
+  color: #aeb6c2;
+}
+
 /* ---- 网格 ---- */
 .weq-cache-avatar-scroll {
   flex: 1 1 auto;

--- a/apps/desktop/src/renderer/src/styles/cache.css
+++ b/apps/desktop/src/renderer/src/styles/cache.css
@@ -3152,13 +3152,26 @@ html[data-theme="dark"] .weq-filerow-name {
  * 整体分析入口按钮（资源分类列表顶部 / 收起态细条）
  * ════════════════════════════════════════════════════════════════════════ */
 
+/* 入口按钮行：整体分析 + 清理释放 并排一行，等宽平分。 */
+.weq-cache-actions {
+  display: flex;
+  gap: 6px;
+  margin: 0 2px 8px;
+}
+
+.weq-cache-actions .weq-cache-analyze-btn {
+  flex: 1 1 0;
+  min-width: 0;
+  margin: 0;
+}
+
 .weq-cache-analyze-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 7px;
+  gap: 6px;
   margin: 0 2px 8px;
-  padding: 9px 11px;
+  padding: 9px 8px;
   border: 1px solid color-mix(in srgb, var(--weq-accent-effective) 32%, transparent);
   border-radius: 9px;
   background: color-mix(in srgb, var(--weq-accent-effective) 12%, transparent);
@@ -3600,7 +3613,7 @@ html[data-theme="dark"] .weq-filerow-name {
 .weq-ra-bars {
   display: flex;
   flex-direction: column;
-  gap: 11px;
+  gap: 6px;
 }
 
 .weq-ra-bar-row {
@@ -3861,4 +3874,542 @@ html[data-theme="dark"] .weq-filerow-name {
 
 .weq-ra-pending .weq-spin {
   animation: weq-cache-spin 900ms linear infinite;
+}
+
+/* ══════════════════════════════════════════════════════════════════════════
+   清理释放 (ResourceCleanupDialog)
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* 入口按钮的清理变体（红色调），继承 .weq-cache-analyze-btn / -rail 基样式 */
+.weq-cache-clean-btn {
+  border-color: color-mix(in srgb, #e5484d 32%, transparent);
+  background: color-mix(in srgb, #e5484d 10%, transparent);
+  color: #e5484d;
+}
+.weq-cache-clean-btn:hover {
+  background: color-mix(in srgb, #e5484d 18%, transparent);
+}
+.weq-cache-clean-rail {
+  border-color: color-mix(in srgb, #e5484d 30%, transparent);
+  background: color-mix(in srgb, #e5484d 10%, transparent);
+  color: #e5484d;
+}
+.weq-cache-clean-rail:hover {
+  background: color-mix(in srgb, #e5484d 20%, transparent);
+}
+
+.weq-clean-dialog {
+  width: min(680px, 100%);
+}
+
+.weq-clean-total {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--weq-fg-secondary);
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--weq-fg-muted) 14%, transparent);
+}
+
+.weq-clean-body {
+  gap: 12px;
+}
+
+/* ── 模式选择 ─────────────────────────────────────────────────────────────── */
+.weq-clean-modes {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.weq-clean-mode {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  padding: 14px 15px;
+  text-align: left;
+  border: 1px solid var(--weq-border-subtle);
+  border-radius: 13px;
+  background: var(--weq-bg-elevated);
+  cursor: pointer;
+  transition: border-color 130ms ease, background-color 130ms ease, transform 130ms ease, box-shadow 130ms ease;
+}
+.weq-clean-mode:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--weq-accent-effective) 45%, transparent);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1px);
+}
+.weq-clean-mode:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.weq-clean-mode-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  flex: 0 0 auto;
+  border-radius: 11px;
+  color: var(--weq-accent-effective);
+  background: color-mix(in srgb, var(--weq-accent-effective) 14%, transparent);
+}
+
+.weq-clean-mode-body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.weq-clean-mode-body strong {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--weq-fg-primary);
+}
+.weq-clean-mode-body small {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--weq-fg-secondary);
+}
+
+.weq-clean-mode-size {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--weq-accent-effective);
+  white-space: nowrap;
+}
+
+/* danger / extreme 模式的红色调 */
+.weq-clean-mode.is-danger .weq-clean-mode-icon {
+  color: #e5484d;
+  background: color-mix(in srgb, #e5484d 13%, transparent);
+}
+.weq-clean-mode.is-danger .weq-clean-mode-size {
+  color: #e5484d;
+}
+.weq-clean-mode.is-danger:hover:not(:disabled) {
+  border-color: color-mix(in srgb, #e5484d 45%, transparent);
+}
+.weq-clean-mode.is-extreme {
+  border-color: color-mix(in srgb, #e5484d 26%, transparent);
+  background: color-mix(in srgb, #e5484d 6%, var(--weq-bg-elevated));
+}
+
+.weq-clean-mode.is-custom .weq-clean-mode-icon {
+  color: var(--weq-fg-secondary);
+  background: color-mix(in srgb, var(--weq-fg-muted) 15%, transparent);
+}
+.weq-clean-mode.is-custom .weq-clean-mode-size {
+  color: var(--weq-fg-muted);
+}
+
+/* ── 自定义面板 ───────────────────────────────────────────────────────────── */
+.weq-clean-custom,
+.weq-clean-confirm {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.weq-clean-back {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px 5px 6px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--weq-fg-secondary);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.weq-clean-back:hover {
+  background: color-mix(in srgb, var(--weq-fg-muted) 12%, transparent);
+  color: var(--weq-fg-primary);
+}
+
+.weq-clean-target-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.weq-clean-target {
+  border: 1px solid var(--weq-border-subtle);
+  border-radius: 11px;
+  background: var(--weq-bg-elevated);
+  overflow: hidden;
+  transition: border-color 130ms ease;
+}
+.weq-clean-target.is-on {
+  border-color: color-mix(in srgb, var(--weq-accent-effective) 50%, transparent);
+  background: color-mix(in srgb, var(--weq-accent-effective) 6%, var(--weq-bg-elevated));
+}
+.weq-clean-target.is-disabled {
+  opacity: 0.5;
+}
+
+.weq-clean-target-main {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  padding: 11px 13px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+.weq-clean-target.is-disabled .weq-clean-target-main {
+  cursor: not-allowed;
+}
+
+.weq-clean-check {
+  display: inline-grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 auto;
+  border-radius: 6px;
+  border: 1.5px solid color-mix(in srgb, var(--weq-fg-muted) 45%, transparent);
+  color: #fff;
+}
+.weq-clean-check.is-on {
+  border-color: var(--weq-accent-effective);
+  background: var(--weq-accent-effective);
+}
+
+.weq-clean-target-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  border-radius: 8px;
+  color: var(--weq-fg-secondary);
+  background: color-mix(in srgb, var(--weq-fg-muted) 12%, transparent);
+}
+
+.weq-clean-target-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.weq-clean-target-text strong {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--weq-fg-primary);
+}
+.weq-clean-target-text small {
+  font-size: 11.5px;
+  color: var(--weq-fg-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.weq-clean-tier {
+  font-style: normal;
+  font-size: 10.5px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 999px;
+}
+.weq-clean-tier.is-safe {
+  color: #2e9c6a;
+  background: color-mix(in srgb, #2e9c6a 15%, transparent);
+}
+.weq-clean-tier.is-caution {
+  color: #d9822b;
+  background: color-mix(in srgb, #d9822b 15%, transparent);
+}
+
+.weq-clean-target-size {
+  flex: 0 0 auto;
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--weq-fg-secondary);
+  white-space: nowrap;
+}
+
+.weq-clean-variants {
+  display: flex;
+  gap: 7px;
+  padding: 0 13px 11px 54px;
+}
+.weq-clean-variants button {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  padding: 5px 10px;
+  border: 1px solid var(--weq-border-subtle);
+  border-radius: 8px;
+  background: var(--weq-bg-surface);
+  color: var(--weq-fg-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background-color 120ms ease;
+}
+.weq-clean-variants button i {
+  font-style: normal;
+  font-size: 10.5px;
+  font-weight: 500;
+  opacity: 0.75;
+}
+.weq-clean-variants button.is-on {
+  border-color: var(--weq-accent-effective);
+  color: var(--weq-accent-effective);
+  background: color-mix(in srgb, var(--weq-accent-effective) 12%, transparent);
+}
+
+.weq-clean-custom-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 4px;
+}
+.weq-clean-custom-foot > span {
+  font-size: 12.5px;
+  color: var(--weq-fg-secondary);
+}
+.weq-clean-custom-foot strong {
+  color: var(--weq-fg-primary);
+}
+
+/* ── 确认步 ───────────────────────────────────────────────────────────────── */
+.weq-clean-summary {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  padding: 14px 15px;
+  border-radius: 13px;
+  border: 1px solid color-mix(in srgb, var(--weq-accent-effective) 30%, transparent);
+  background: color-mix(in srgb, var(--weq-accent-effective) 8%, var(--weq-bg-elevated));
+}
+.weq-clean-summary.is-danger {
+  border-color: color-mix(in srgb, #e5484d 34%, transparent);
+  background: color-mix(in srgb, #e5484d 8%, var(--weq-bg-elevated));
+}
+.weq-clean-summary-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+  border-radius: 11px;
+  color: var(--weq-accent-effective);
+  background: color-mix(in srgb, var(--weq-accent-effective) 15%, transparent);
+}
+.weq-clean-summary.is-danger .weq-clean-summary-icon {
+  color: #e5484d;
+  background: color-mix(in srgb, #e5484d 14%, transparent);
+}
+.weq-clean-summary > div {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.weq-clean-summary strong {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--weq-fg-primary);
+}
+.weq-clean-summary p {
+  margin: 3px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--weq-fg-secondary);
+}
+.weq-clean-summary-size {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+}
+.weq-clean-summary-size b {
+  font-size: 16px;
+  font-weight: 800;
+  color: var(--weq-fg-primary);
+}
+.weq-clean-summary-size small {
+  font-size: 11px;
+  color: var(--weq-fg-muted);
+}
+
+.weq-clean-review {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--weq-border-subtle);
+  border-radius: 11px;
+  overflow: hidden;
+}
+.weq-clean-review-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 13px;
+}
+.weq-clean-review-row + .weq-clean-review-row {
+  border-top: 1px solid var(--weq-border-subtle);
+}
+.weq-clean-review-label {
+  flex: 1 1 auto;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--weq-fg-primary);
+}
+.weq-clean-review-variant {
+  font-style: normal;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: 999px;
+  color: var(--weq-accent-effective);
+  background: color-mix(in srgb, var(--weq-accent-effective) 13%, transparent);
+}
+.weq-clean-review-size {
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--weq-fg-secondary);
+}
+
+.weq-clean-empty {
+  padding: 24px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--weq-fg-muted);
+}
+
+.weq-clean-phrase {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.weq-clean-phrase > span {
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--weq-fg-secondary);
+}
+.weq-clean-phrase b {
+  color: #e5484d;
+}
+.weq-clean-phrase input {
+  padding: 9px 12px;
+  border: 1px solid color-mix(in srgb, #e5484d 34%, transparent);
+  border-radius: 9px;
+  background: var(--weq-bg-surface);
+  color: var(--weq-fg-primary);
+  font-size: 13px;
+}
+.weq-clean-phrase input:focus {
+  outline: none;
+  border-color: #e5484d;
+}
+
+/* ── 底部按钮 ─────────────────────────────────────────────────────────────── */
+.weq-clean-confirm-foot,
+.weq-clean-done-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding-top: 4px;
+}
+.weq-clean-cancel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 16px;
+  border: 1px solid var(--weq-border-subtle);
+  border-radius: 9px;
+  background: var(--weq-bg-surface);
+  color: var(--weq-fg-secondary);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.weq-clean-cancel:hover {
+  color: var(--weq-fg-primary);
+  border-color: color-mix(in srgb, var(--weq-fg-muted) 40%, transparent);
+}
+.weq-clean-go {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 16px;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  background: var(--weq-accent-effective);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: filter 130ms ease, opacity 130ms ease;
+}
+.weq-clean-go:hover:not(:disabled) {
+  filter: brightness(1.06);
+}
+.weq-clean-go.is-danger {
+  background: #e5484d;
+}
+.weq-clean-go:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ── 执行中 / 完成 ────────────────────────────────────────────────────────── */
+.weq-clean-running,
+.weq-clean-done {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+  padding: 40px 20px 28px;
+  text-align: center;
+}
+.weq-clean-running .weq-spin {
+  color: var(--weq-accent-effective);
+  animation: weq-cache-spin 900ms linear infinite;
+}
+.weq-clean-running strong {
+  font-size: 15px;
+  color: var(--weq-fg-primary);
+}
+.weq-clean-running span {
+  font-size: 12.5px;
+  color: var(--weq-fg-secondary);
+}
+
+.weq-clean-done-icon {
+  color: #2e9c6a;
+}
+.weq-clean-done-title {
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--weq-fg-primary);
+}
+.weq-clean-done-desc {
+  margin: 0;
+  max-width: 420px;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--weq-fg-secondary);
+}
+.weq-clean-done-actions {
+  justify-content: center;
+  padding-top: 8px;
 }

--- a/apps/desktop/src/renderer/src/styles/cache.css
+++ b/apps/desktop/src/renderer/src/styles/cache.css
@@ -3592,6 +3592,127 @@ html[data-theme="dark"] .weq-filerow-name {
   font-size: 12.5px;
 }
 
+/* 各分类横向排行条 */
+.weq-ra-barwrap {
+  width: 100%;
+}
+
+.weq-ra-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+}
+
+.weq-ra-bar-row {
+  display: grid;
+  grid-template-columns: 92px 1fr auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.weq-ra-bar-label {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--weq-fg-primary);
+  white-space: nowrap;
+}
+
+.weq-ra-bar-label i {
+  flex: none;
+  width: 9px;
+  height: 9px;
+  border-radius: 3px;
+}
+
+.weq-ra-bar-track {
+  height: 9px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--weq-fg-primary) 8%, transparent);
+  overflow: hidden;
+}
+
+.weq-ra-bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  transition: width 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.weq-ra-bar-val {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+  min-width: 108px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.weq-ra-bar-val b {
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--weq-fg-primary);
+}
+
+.weq-ra-bar-val small {
+  font-size: 10.5px;
+  color: var(--weq-fg-muted);
+}
+
+/* 源文件/缩略图 百分比堆叠条 */
+.weq-ra-sharewrap {
+  width: 100%;
+}
+
+.weq-ra-sharebar {
+  display: flex;
+  gap: 2px;
+  height: 14px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--weq-fg-primary) 8%, transparent);
+}
+
+.weq-ra-shareseg {
+  height: 100%;
+  min-width: 3px;
+  transition: width 420ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.weq-ra-sharelegend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 22px;
+  margin-top: 14px;
+}
+
+.weq-ra-shareitem {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12.5px;
+}
+
+.weq-ra-shareitem i {
+  flex: none;
+  width: 9px;
+  height: 9px;
+  border-radius: 3px;
+}
+
+.weq-ra-share-lbl {
+  color: var(--weq-fg-primary);
+  font-weight: 600;
+}
+
+.weq-ra-share-val {
+  color: var(--weq-fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+
 /* 月度柱状图 */
 .weq-ra-monthwrap {
   width: 100%;

--- a/apps/desktop/src/renderer/src/styles/export.css
+++ b/apps/desktop/src/renderer/src/styles/export.css
@@ -1878,3 +1878,120 @@ html[data-theme="dark"] .weq-exp-sched-empty {
   border-color: rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.02);
 }
+
+/* ---- 导出联系人（好友分组 chips / 群成员切换） ---- */
+.weq-exp-contacts {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.weq-exp-contacts-switch {
+  padding: 12px 16px 10px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.weq-exp-cats {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.weq-exp-cats-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 16px 8px;
+}
+
+.weq-exp-cats-head strong {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: #1c2c40;
+}
+
+.weq-exp-cats-head small {
+  font-size: 11.5px;
+  color: #8a98ad;
+}
+
+.weq-exp-cats-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  gap: 8px;
+  padding: 4px 16px 16px;
+}
+
+.weq-exp-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 999px;
+  background: color-mix(in srgb, #ffffff 40%, transparent);
+  color: #2b3a4d;
+  font-size: 12.5px;
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s, color 0.12s;
+}
+
+.weq-exp-chip:hover {
+  border-color: rgba(0, 153, 255, 0.5);
+  color: #0099ff;
+}
+
+.weq-exp-chip b {
+  font-weight: 600;
+  font-size: 11px;
+  color: #8a98ad;
+}
+
+.weq-exp-chip.is-active {
+  border-color: #0099ff;
+  background: rgba(0, 153, 255, 0.1);
+  color: #0099ff;
+}
+
+.weq-exp-chip.is-active b {
+  color: #0099ff;
+}
+
+.weq-exp-cats-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 36px 16px;
+  color: #8a98ad;
+}
+
+html[data-theme="dark"] .weq-exp-contacts-switch {
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+html[data-theme="dark"] .weq-exp-cats-head strong {
+  color: #e9eef5;
+}
+
+html[data-theme="dark"] .weq-exp-chip {
+  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.03);
+  color: #cbd5e1;
+}
+
+html[data-theme="dark"] .weq-exp-chip.is-active {
+  border-color: #0099ff;
+  background: rgba(0, 153, 255, 0.16);
+  color: #4db8ff;
+}
+
+html[data-theme="dark"] .weq-exp-chip.is-active b {
+  color: #4db8ff;
+}

--- a/apps/desktop/src/renderer/src/styles/index.css
+++ b/apps/desktop/src/renderer/src/styles/index.css
@@ -6372,6 +6372,41 @@ html[data-theme="dark"] .weq-ark-map-name {
   overflow: hidden;
 }
 
+/* 红包类型小字 / 专属领取人：叠在封面图上，紧贴居中标题的上方一点 */
+.weq-redbag-tag {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 44%; /* 占封面上半，内容底对齐 → 落在标题正上方 */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 3px;
+  padding: 0 8px 3px;
+  line-height: 1.2;
+  font-size: 11px;
+  color: #fbe4b5; /* 与标题同系米黄 */
+  text-align: center;
+  text-shadow: 0 1px 2px rgba(120, 20, 10, 0.45);
+  pointer-events: none;
+}
+.weq-redbag-tag-avatar {
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+
+/* 专属红包：头像+文字整块及标题一起下移一点，避免头像盖住封面顶部的 QQ logo。 */
+.weq-redbag-tag--designated {
+  transform: translateY(14px);
+}
+.weq-redbag-card--designated .weq-redbag-title {
+  /* 保留原居中变换，叠加下移量。 */
+  transform: translate(-50%, calc(-50% + 14px));
+}
+
 /* --- floating forward window stack ----------------------------- */
 
 .weq-forward-layer {

--- a/apps/desktop/src/renderer/src/styles/index.css
+++ b/apps/desktop/src/renderer/src/styles/index.css
@@ -1047,6 +1047,12 @@ html[data-theme="dark"] .chat-empty {
   cursor: zoom-out;
 }
 
+/* 缩放/平移的舞台：入场动画放在这层，媒体自身承载 zoom 的 transform。 */
+.weq-lightbox-stage {
+  display: grid;
+  place-items: center;
+}
+
 .weq-lightbox-image {
   max-width: 66vw;
   max-height: 66vh;
@@ -1054,6 +1060,8 @@ html[data-theme="dark"] .chat-empty {
   border-radius: 6px;
   box-shadow: 0 24px 80px -20px rgba(0, 0, 0, 0.7);
   cursor: default;
+  /* transform-origin 保持默认居中，useZoomPan 的锚点数学依赖于此。 */
+  transform-origin: center center;
 }
 
 .weq-lightbox-close {

--- a/apps/desktop/src/renderer/src/styles/index.css
+++ b/apps/desktop/src/renderer/src/styles/index.css
@@ -5497,6 +5497,35 @@ html[data-theme="dark"] .weq-profile-member .avatar {
   background: color-mix(in srgb, var(--weq-accent-effective) 14%, transparent);
 }
 
+/* 消息气泡里的发送者头像 → 可点击弹资料卡片。button 重置为纯头像容器。 */
+.message-avatar-button {
+  flex: none;
+  display: block;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: none;
+  cursor: pointer;
+  -webkit-app-region: no-drag;
+  transition: transform 130ms ease;
+}
+
+.message-avatar-button .avatar {
+  transition: box-shadow 130ms ease;
+}
+
+.message-avatar-button:hover {
+  transform: translateY(-1px);
+}
+
+.message-avatar-button:hover .avatar {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--weq-accent-effective) 55%, transparent);
+}
+
+.message-avatar-button:active {
+  transform: none;
+}
+
 html[data-theme="dark"] .weq-member-pop {
   border-color: color-mix(in srgb, var(--weq-accent-effective) 26%, transparent);
   background:
@@ -6123,6 +6152,22 @@ html[data-theme="dark"] .chat-empty {
 }
 .weq-ark-footer-icon { width: 12px; height: 12px; border-radius: 2px; object-fit: cover; }
 
+/* 群公告卡 (com.tencent.mannounce)：喇叭头 + 标题 + 多行正文 */
+.weq-ark-announce { cursor: default; }
+.weq-ark-announce:hover { background-color: #ffffff; }
+.weq-ark-announce-icon { color: #ff9c19; flex-shrink: 0; }
+.weq-ark-announce-text {
+  font-size: 13px;
+  color: #666666;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 6;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* ---- Ark 卡片深色模式 ---- The demo only ships light colors; map them onto the
    theme tokens so the structured card reads correctly on the dark canvas. */
 html[data-theme="dark"] .weq-ark-container {
@@ -6136,6 +6181,8 @@ html[data-theme="dark"] .weq-ark-container:hover {
 html[data-theme="dark"] .weq-ark-header { color: var(--weq-fg-muted); }
 html[data-theme="dark"] .weq-ark-title { color: var(--weq-fg-primary); }
 html[data-theme="dark"] .weq-ark-desc { color: var(--weq-fg-secondary); }
+html[data-theme="dark"] .weq-ark-announce-text { color: var(--weq-fg-secondary); }
+html[data-theme="dark"] .weq-ark-announce:hover { background-color: var(--weq-bg-surface); }
 html[data-theme="dark"] .weq-ark-preview-small,
 html[data-theme="dark"] .weq-ark-preview-big {
   background: rgba(255, 255, 255, 0.06);

--- a/apps/desktop/src/renderer/src/styles/index.css
+++ b/apps/desktop/src/renderer/src/styles/index.css
@@ -2828,7 +2828,9 @@ html[data-theme="dark"] .app-title-bar-signature {
   border-radius: 10px;
 }
 
-/* Manual lock button — sits just above the account avatar. */
+/* Manual 深/浅 toggle + lock button — both sit just above the account avatar,
+   share the same pill shape so they read as one stacked control cluster. */
+.app-shell .rail-footer .weq-rail-theme-btn,
 .app-shell .rail-footer .weq-rail-lock-btn {
   display: grid;
   place-items: center;
@@ -2841,6 +2843,7 @@ html[data-theme="dark"] .app-title-bar-signature {
   transition: color 140ms ease, background-color 140ms ease, border-color 140ms ease;
 }
 
+.app-shell .rail-footer .weq-rail-theme-btn:hover:not(:disabled),
 .app-shell .rail-footer .weq-rail-lock-btn:hover:not(:disabled) {
   color: #0099ff;
   border-color: rgba(0, 153, 255, 0.34);
@@ -2850,6 +2853,12 @@ html[data-theme="dark"] .app-title-bar-signature {
 .app-shell .rail-footer .weq-rail-lock-btn:disabled {
   opacity: 0.45;
   cursor: not-allowed;
+}
+
+html[data-theme='dark'] .app-shell .rail-footer .weq-rail-theme-btn,
+html[data-theme='dark'] .app-shell .rail-footer .weq-rail-lock-btn {
+  color: #9fb2c6;
+  border-color: rgba(0, 153, 255, 0.28);
 }
 
 /* Popover buttons should not be constrained by rail-footer button styles */
@@ -4436,6 +4445,92 @@ html[data-theme='dark'] .weq-set-input {
 .weq-set-btn:disabled {
   opacity: 0.45;
   cursor: not-allowed;
+}
+
+/* Destructive action (清理缓存). */
+.weq-set-btn-danger {
+  background: #ef4444;
+  border-color: #ef4444;
+  color: #ffffff;
+}
+
+.weq-set-btn-danger:hover:not(:disabled) {
+  filter: brightness(1.06);
+}
+
+/* 清理缓存 — per-category checkbox rows. */
+.weq-set-cache-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.weq-set-cache-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 8px;
+  font-size: 13px;
+  color: #374151;
+  cursor: pointer;
+  transition: background-color 140ms ease, border-color 140ms ease;
+}
+
+.weq-set-cache-item:hover {
+  background: rgba(0, 153, 255, 0.05);
+  border-color: rgba(0, 153, 255, 0.2);
+}
+
+.weq-set-cache-item input {
+  accent-color: var(--weq-accent-effective);
+}
+
+.weq-set-cache-item svg {
+  color: #6b7280;
+  flex: none;
+}
+
+.weq-set-cache-label {
+  flex: 1 1 auto;
+}
+
+.weq-set-cache-size {
+  color: #6b7280;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.weq-set-cache-total {
+  flex: 1 1 auto;
+  align-self: center;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.weq-set-cache-total strong {
+  color: #374151;
+}
+
+html[data-theme='dark'] .weq-set-cache-item {
+  border-color: rgba(255, 255, 255, 0.1);
+  color: #cbd5e1;
+}
+
+html[data-theme='dark'] .weq-set-cache-item:hover {
+  background: rgba(0, 153, 255, 0.1);
+}
+
+html[data-theme='dark'] .weq-set-cache-size,
+html[data-theme='dark'] .weq-set-cache-total {
+  color: #94a3b8;
+}
+
+html[data-theme='dark'] .weq-set-cache-total strong,
+html[data-theme='dark'] .weq-set-cache-item svg {
+  color: #cbd5e1;
 }
 
 /* Media-type checkbox pills */

--- a/apps/desktop/src/renderer/src/styles/index.css
+++ b/apps/desktop/src/renderer/src/styles/index.css
@@ -8767,6 +8767,74 @@ html[data-theme="dark"] .weq-persona-modal {
   height: min(60vh, 480px);
 }
 
+/* ─────────────────────────────────────────────────────────────────────────
+   View-deleted-messages panel (components/compose/DeletedMessagesModal)
+   Reuses the chat `.message-scroll` + `MessageBubble`, so bubbles look exactly
+   like the live chat; only the per-row 恢复 affordance is bespoke.
+   ───────────────────────────────────────────────────────────────────────── */
+.weq-deleted {
+  display: flex;
+  flex-direction: column;
+  max-height: min(80vh, 680px);
+  color: var(--weq-fg-primary);
+  background: var(--weq-bg-surface);
+}
+.weq-deleted-scroll {
+  flex: 1;
+  min-height: 0;
+  height: min(64vh, 560px);
+}
+.weq-deleted-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  height: 100%;
+  padding: 2rem 1.5rem;
+  text-align: center;
+  color: var(--weq-fg-secondary);
+}
+.weq-deleted-empty small {
+  font-size: 12px;
+  color: var(--weq-fg-tertiary, var(--weq-fg-secondary));
+  max-width: 20rem;
+}
+/* Wrap each reused bubble so the restore action can float over its corner. */
+.weq-deleted-row {
+  position: relative;
+}
+.weq-deleted-row .weq-deleted-restore {
+  position: absolute;
+  top: 2px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 9px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--weq-fg-secondary);
+  background: var(--weq-bg-surface);
+  border: 1px solid var(--weq-border-subtle);
+  border-radius: 999px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.weq-deleted-row:hover .weq-deleted-restore,
+.weq-deleted-row .weq-deleted-restore:disabled {
+  opacity: 1;
+}
+.weq-deleted-row .weq-deleted-restore:hover {
+  color: var(--weq-accent, #2f7bff);
+  border-color: var(--weq-accent, #2f7bff);
+}
+.weq-deleted-row .weq-deleted-restore:disabled {
+  cursor: default;
+  color: var(--weq-fg-tertiary, var(--weq-fg-secondary));
+}
+
 /* face picker */
 .weq-face-picker,
 .weq-people-picker { display: flex; flex-direction: column; min-height: 0; height: 100%; }

--- a/apps/desktop/src/renderer/src/styles/index.css
+++ b/apps/desktop/src/renderer/src/styles/index.css
@@ -5385,6 +5385,141 @@ html[data-theme="dark"] .weq-profile-member .avatar {
 }
 
 /* ──────────────────────────────────────────────────────────────────────
+ * 群成员资料卡片（MemberProfileCard）。贴光标弹出的 anchored 浮层：
+ * scrim 只作透明点击捕获（无遮罩、不虚化，避免打断阅读），卡片本体沿用
+ * weq-profile 的设计语言，宽度更紧凑。定位由组件 inline style(fixed+left/top)
+ * 负责，这里只管观感。
+ * ──────────────────────────────────────────────────────────────────── */
+.weq-member-pop-scrim {
+  /* position/inset/z-index 由组件 inline 设定；此处仅兜底 */
+  background: transparent;
+}
+
+.weq-member-pop {
+  display: flex;
+  flex-direction: column;
+  width: 288px;
+  max-width: calc(100vw - 24px);
+  max-height: calc(100vh - 24px);
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 22px 16px 14px;
+  border: 1px solid color-mix(in srgb, var(--weq-accent-effective) 20%, transparent);
+  border-radius: 14px;
+  background:
+    radial-gradient(
+      ellipse at 50% -10%,
+      color-mix(in srgb, var(--weq-accent-effective) 10%, transparent),
+      transparent 48%
+    ),
+    rgba(255, 255, 255, 0.99);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.6) inset,
+    0 20px 48px -18px rgba(7, 31, 61, 0.5);
+  transition: opacity 120ms ease;
+}
+
+.weq-member-pop .weq-profile-close {
+  top: 8px;
+  right: 8px;
+}
+
+/* 角色 pill：群主=金色渐变、管理员=柔和绿，压过默认主题色关系 pill。 */
+.weq-profile-rel.is-owner {
+  border-color: transparent;
+  background: linear-gradient(135deg, #ffd66b, #f5a623);
+  color: #5a3a00;
+  box-shadow: 0 6px 14px -8px rgba(245, 166, 35, 0.7);
+}
+
+.weq-profile-rel.is-admin {
+  border-color: transparent;
+  background: linear-gradient(135deg, #7fe0b0, #2fb87a);
+  color: #05391f;
+  box-shadow: 0 6px 14px -8px rgba(47, 184, 122, 0.6);
+}
+
+/* 专属头衔 pill：主题渐变填充，突出但不喧宾夺主。 */
+.weq-member-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 11px;
+  border-radius: 999px;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--weq-accent-effective) 72%, white),
+    var(--weq-accent-effective)
+  );
+  color: #ffffff;
+  font-size: 12px;
+  font-weight: 600;
+  box-shadow: 0 6px 14px -8px rgba(0, 122, 204, 0.6);
+}
+
+.weq-member-title svg {
+  flex: none;
+}
+
+/* 底部资料补全中的轻量提示。 */
+.weq-member-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 10px;
+  color: #7c8a99;
+  font-size: 11.5px;
+}
+
+.weq-member-loading svg {
+  animation: weq-spin 0.9s linear infinite;
+}
+
+@keyframes weq-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* 群成员行可点击态：hover 高亮 + 手型，提示可查看资料。 */
+.group-info-member-row.is-clickable {
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background-color 130ms ease;
+}
+
+.group-info-member-row.is-clickable:hover {
+  background: color-mix(in srgb, var(--weq-accent-effective) 9%, transparent);
+}
+
+.group-info-member-row.is-clickable:active {
+  background: color-mix(in srgb, var(--weq-accent-effective) 14%, transparent);
+}
+
+html[data-theme="dark"] .weq-member-pop {
+  border-color: color-mix(in srgb, var(--weq-accent-effective) 26%, transparent);
+  background:
+    radial-gradient(
+      ellipse at 50% -10%,
+      color-mix(in srgb, var(--weq-accent-effective) 16%, transparent),
+      transparent 48%
+    ),
+    #1c2028;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset,
+    0 20px 48px -18px rgba(0, 0, 0, 0.7);
+}
+
+html[data-theme="dark"] .weq-member-loading {
+  color: #8c98a6;
+}
+
+html[data-theme="dark"] .group-info-member-row.is-clickable:hover {
+  background: color-mix(in srgb, var(--weq-accent-effective) 16%, transparent);
+}
+
+/* ──────────────────────────────────────────────────────────────────────
  * 好友 / 群通知灯箱（ContactNoticeDialog / GroupNoticeDialog）。
  * 复用 .weq-profile-layer 遮罩；固定标题 + 可滚动列表，复用 .notice-card 卡片。
  * ──────────────────────────────────────────────────────────────────── */

--- a/apps/desktop/src/renderer/src/views/ChatHome.tsx
+++ b/apps/desktop/src/renderer/src/views/ChatHome.tsx
@@ -2,7 +2,7 @@
  * 聊天页门面（无选中会话时的落地页）。三段式，纯装饰、无交互：
  *
  *   ① 品牌 logo + 大字细体问候（按时间 Good morning/… + QQ 昵称）
- *   ② 一言打字机：从 hitokoto 池随机取句，逐字打出→停顿→逆序退回→下一句
+ *   ② 一言打字机：从 hitokoto 池随机取一句，逐字打出后定格（光标继续闪烁、不再切换句）
  *   ③ 记忆长廊：把私聊里「别人发来」的真实短句排成一条时间线，纯 CSS 匀速上浮（悬停
  *     暂停），像回忆浮现又淡去——真·旧消息就是最贴「回忆」主题的素材
  *
@@ -60,7 +60,10 @@ function Avatar({ uin, name }: { uin: string; name: string }) {
   );
 }
 
-/** ② 一言打字机（独立组件，隔离高频 setState）。 */
+/**
+ * ② 一言打字机（独立组件，隔离高频 setState）。取随机一句逐字打出，打完即定格——
+ * 光标继续闪烁、句子不再切换。随机性来自后端每次进首页重新洗牌（verses[0] 即随机）。
+ */
 function HitokotoTicker({ verses }: { verses: Verse[] }) {
   const [display, setDisplay] = useState('');
   const [from, setFrom] = useState('');
@@ -70,49 +73,27 @@ function HitokotoTicker({ verses }: { verses: Verse[] }) {
     if (verses.length === 0) return undefined;
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout>;
-    let vi = 0;
 
-    const typeVerse = (): void => {
+    const verse = verses[0]!;
+    const chars = [...verse.text];
+    setFrom(verse.from);
+    setShowFrom(false);
+    setDisplay('');
+    let i = 0;
+
+    const typeChar = (): void => {
       if (cancelled) return;
-      const verse = verses[vi % verses.length]!;
-      const chars = [...verse.text];
-      setFrom(verse.from);
-      setShowFrom(false);
-      let i = 0;
-
-      const typeChar = (): void => {
-        if (cancelled) return;
-        i += 1;
-        setDisplay(chars.slice(0, i).join(''));
-        if (i < chars.length) {
-          timer = setTimeout(typeChar, 58 + Math.random() * 52);
-        } else {
-          setShowFrom(true);
-          timer = setTimeout(erase, 2400);
-        }
-      };
-
-      const erase = (): void => {
-        if (cancelled) return;
-        setShowFrom(false);
-        const eraseChar = (): void => {
-          if (cancelled) return;
-          i -= 1;
-          setDisplay(chars.slice(0, Math.max(0, i)).join(''));
-          if (i > 0) {
-            timer = setTimeout(eraseChar, 22);
-          } else {
-            vi += 1;
-            timer = setTimeout(typeVerse, 360);
-          }
-        };
-        eraseChar();
-      };
-
-      timer = setTimeout(typeChar, 280);
+      i += 1;
+      setDisplay(chars.slice(0, i).join(''));
+      if (i < chars.length) {
+        timer = setTimeout(typeChar, 58 + Math.random() * 52);
+      } else {
+        // 打完定格：显示出处，光标留在句尾继续闪烁，不再退回/切换。
+        setShowFrom(true);
+      }
     };
 
-    typeVerse();
+    timer = setTimeout(typeChar, 280);
     return () => {
       cancelled = true;
       clearTimeout(timer);
@@ -227,7 +208,7 @@ export function ChatHome({ nickname }: { nickname: string }) {
           <img
             src={logoUrl}
             alt="WeQ"
-            className="weq-chathome-logo weq-splash-logo"
+            className="weq-chathome-logo"
             width={72}
             height={72}
           />

--- a/apps/desktop/src/renderer/src/views/ExportView.tsx
+++ b/apps/desktop/src/renderer/src/views/ExportView.tsx
@@ -17,6 +17,7 @@
 import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react';
 import {
   CalendarClock,
+  Contact,
   DatabaseZap,
   FlaskConical,
   Globe,
@@ -25,6 +26,8 @@ import {
   Pause,
   Play,
   Trash2,
+  Users,
+  UserRound,
   Zap,
 } from 'lucide-react';
 import { trpc, client } from '../trpc/client';
@@ -42,7 +45,10 @@ import { AlbumExportLightbox, type AlbumExportResult } from './export/AlbumExpor
 import { FailureLightbox } from './export/FailureLightbox';
 import {
   CHATLAB_FORMATS,
+  DEFAULT_OPTIONS,
+  FRIEND_FORMATS,
   FULL_FORMATS,
+  MEMBER_FORMATS,
   QZONE_FORMATS,
   chatKind,
   convAvatarUrl,
@@ -71,6 +77,7 @@ const MODES: ModeDef[] = [
   { id: 'decrypt', label: '解密数据库', desc: '导出原始 SQLite 供研究', icon: <DatabaseZap size={18} /> },
   { id: 'chatlab', label: 'ChatLab 格式', desc: '供 AI 分析的结构化 JSON', icon: <FlaskConical size={18} /> },
   { id: 'qzone', label: '好友QQ空间导出', desc: '导出好友空间说说（需在线 QQ）', icon: <Globe size={18} /> },
+  { id: 'contacts', label: '导出联系人', desc: '好友列表 / 群成员列表', icon: <Contact size={18} /> },
   { id: 'scheduled', label: '定时导出任务', desc: '按计划自动导出', icon: <CalendarClock size={18} /> },
   { id: 'album', label: '群相册导出', desc: '批量下载群相册', icon: <Images size={18} /> },
 ];
@@ -103,6 +110,16 @@ export function ExportView(): ReactElement {
   const [mode, setMode] = useState<ExportMode>('full');
   const [convSelection, setConvSelection] = useState<Set<string>>(new Set());
   const [dbSelection, setDbSelection] = useState<Set<string>>(new Set());
+  /** 导出联系人：好友 or 群成员。 */
+  const [contactScope, setContactScope] = useState<'friends' | 'group'>('friends');
+  /** 好友导出：选中的分组 id（空 = 全部好友）。 */
+  const [catSelection, setCatSelection] = useState<Set<number>>(new Set());
+  /** 群成员导出：选中的群号。 */
+  const [contactGroupId, setContactGroupId] = useState<string | null>(null);
+
+  const categories = trpc.account.listCategories.useQuery(undefined, {
+    enabled: mode === 'contacts' && contactScope === 'friends',
+  });
   const [decryptLightboxOpen, setDecryptLightboxOpen] = useState(false);
   const [decryptOutputDir, setDecryptOutputDir] = useState<string | null>(null);
   const [albumOutputDir, setAlbumOutputDir] = useState<string | null>(null);
@@ -114,11 +131,20 @@ export function ExportView(): ReactElement {
   /** Media-completion failure detail, when the user opens a task's failure list. */
   const [failureView, setFailureView] = useState<{ name: string; failures: UiFailure[] } | null>(null);
 
-  // ChatLab only emits json/jsonl; 好友空间 only json/txt — clamp on mode entry.
+  // ChatLab only emits json/jsonl; 好友空间 only json/txt; 联系人受子类限制 — clamp.
   useEffect(() => {
     if (mode === 'chatlab' && format !== 'json' && format !== 'jsonl') setFormat('json');
     if (mode === 'qzone' && format !== 'json' && format !== 'txt') setFormat('json');
-  }, [mode, format]);
+    if (mode === 'contacts') {
+      const allowed =
+        contactScope === 'friends'
+          ? ['csv', 'xlsx', 'json', 'txt', 'vcard']
+          : ['csv', 'xlsx', 'json', 'txt'];
+      if (!allowed.includes(format)) setFormat('csv');
+    }
+    // vcard 仅联系人可用；离开联系人模式时清掉，避免带进消息/定时导出。
+    if (mode !== 'contacts' && format === 'vcard') setFormat('json');
+  }, [mode, contactScope, format]);
 
   // Live task progress: invalidate the list whenever the backend ticks.
   useEffect(() => {
@@ -165,6 +191,15 @@ export function ExportView(): ReactElement {
       meta: `${fmtCount(g.memberCount || 0)} 人`,
     }));
   }, [groups.data]);
+
+  // 好友分组 chips（导出联系人 · 好友）。
+  const catItems = useMemo<Array<{ id: number; name: string; count: number }>>(() => {
+    return ((categories.data ?? []) as Array<{ id: number; name: string; buddyCount: number }>).map(
+      (c) => ({ id: c.id, name: c.name || `分组${c.id}`, count: Number(c.buddyCount ?? 0) }),
+    );
+  }, [categories.data]);
+
+  const friendTotal = useMemo(() => catItems.reduce((sum, c) => sum + c.count, 0), [catItems]);
 
   const dbItems = useMemo<DbPickItem[]>(() => {
     return ((databases.data ?? []) as DbPickItem[]).map((db) => ({
@@ -250,6 +285,11 @@ export function ExportView(): ReactElement {
     if (mode === 'album') {
       if (!albumGroupId) return;
       openAlbumExport();
+      return;
+    }
+    if (mode === 'contacts') {
+      if (contactScope === 'group' && !contactGroupId) return;
+      setLightbox('contacts');
       return;
     }
     if (convSelection.size === 0) return;
@@ -391,6 +431,43 @@ export function ExportView(): ReactElement {
     }
   }
 
+  /** 导出联系人：好友列表（可按分组过滤）或某群成员列表；格式 + 可选头像。 */
+  async function runContactsExport(options: ExportOptions): Promise<void> {
+    // 联系人格式收窄到 startContactsExport 接受的集合（chips 已保证）。
+    const cfmt = format as 'json' | 'csv' | 'xlsx' | 'txt' | 'vcard';
+    setSubmitting(true);
+    try {
+      if (contactScope === 'friends') {
+        const cats = [...catSelection];
+        await client.account.startContactsExport.mutate({
+          scope: 'friends',
+          name: cats.length ? `好友_${cats.length}个分组` : '全部好友',
+          format: cfmt,
+          exportAvatar: options.exportAvatar,
+          ...(cats.length ? { categoryIds: cats } : {}),
+        });
+      } else {
+        const g = groupItems.find((it) => it.id === contactGroupId);
+        if (!g) return;
+        await client.account.startContactsExport.mutate({
+          scope: 'group',
+          groupCode: g.id,
+          name: `${g.name}_群成员`,
+          format: cfmt === 'vcard' ? 'csv' : cfmt,
+          exportAvatar: options.exportAvatar,
+        });
+      }
+      setLightbox(null);
+      setCatSelection(new Set());
+      setContactGroupId(null);
+      refetchTasks();
+    } catch (e) {
+      dialog.error('启动联系人导出失败', e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   async function runFullExport(
     options: ExportOptions,
     opts: { chatlab?: boolean; format?: ExportFormat } = {},
@@ -431,7 +508,7 @@ export function ExportView(): ReactElement {
           kind: t.kind ?? 'c2c',
           conv: t.id,
           name: t.name,
-          format: opts.format ?? format,
+          format: (opts.format ?? format) as Exclude<ExportFormat, 'vcard'>,
           total: t.total ?? 0,
           exportAvatar: options.exportAvatar,
           ...(opts.chatlab ? { chatlab: true } : {}),
@@ -547,6 +624,10 @@ export function ExportView(): ReactElement {
       void runQzoneExport(result.options);
       return;
     }
+    if (lightbox === 'contacts') {
+      void runContactsExport(result.options);
+      return;
+    }
     if (lightbox === 'scheduled') {
       await runCreateSchedule(result);
       return;
@@ -572,7 +653,7 @@ export function ExportView(): ReactElement {
     try {
       await client.account.createSchedule.mutate({
         name: `定时 · ${targets[0]!.name}${targets.length > 1 ? ` 等 ${targets.length} 个` : ''}`,
-        format,
+        format: format as Exclude<ExportFormat, 'vcard'>,
         conversations: targets.map((t) => ({
           id: t.id,
           name: t.name,
@@ -645,8 +726,18 @@ export function ExportView(): ReactElement {
   const activeMode = MODES.find((m) => m.id === mode)!;
   const isMultiConvMode =
     mode === 'full' || mode === 'chatlab' || mode === 'scheduled' || mode === 'qzone';
+  // 显示底部格式 chips 的模式（多选会话 + 导出联系人）。
+  const showFormatChips = isMultiConvMode || mode === 'contacts';
   const formatOptions =
-    mode === 'chatlab' ? CHATLAB_FORMATS : mode === 'qzone' ? QZONE_FORMATS : FULL_FORMATS;
+    mode === 'chatlab'
+      ? CHATLAB_FORMATS
+      : mode === 'qzone'
+        ? QZONE_FORMATS
+        : mode === 'contacts'
+          ? contactScope === 'friends'
+            ? FRIEND_FORMATS
+            : MEMBER_FORMATS
+          : FULL_FORMATS;
   // 好友空间导出只列好友（排除群聊）；其余多选模式用全部会话。
   const pickerItems = mode === 'qzone' ? friendItems : convItems;
 
@@ -661,14 +752,18 @@ export function ExportView(): ReactElement {
             ? '导出空间'
             : mode === 'chatlab'
               ? '导出 ChatLab'
-              : '导出';
+              : mode === 'contacts'
+                ? '导出联系人'
+                : '导出';
 
   const primaryDisabled =
     mode === 'decrypt'
       ? dbSelection.size === 0
       : mode === 'album'
         ? !albumGroupId
-        : convSelection.size === 0;
+        : mode === 'contacts'
+          ? contactScope === 'group' && !contactGroupId
+          : convSelection.size === 0;
 
   // Lightbox summary line.
   const lightboxSummary = (() => {
@@ -676,8 +771,16 @@ export function ExportView(): ReactElement {
       const g = groupItems.find((it) => it.id === albumGroupId);
       return g ? `群相册 · ${g.name}` : '群相册';
     }
-    const n = convSelection.size;
     const fmt = format.toUpperCase();
+    if (lightbox === 'contacts') {
+      if (contactScope === 'group') {
+        const g = groupItems.find((it) => it.id === contactGroupId);
+        return `${g?.name ?? '群成员'} · ${fmt}`;
+      }
+      const n = catSelection.size;
+      return `${n ? `${n} 个分组` : '全部好友'} · ${fmt}`;
+    }
+    const n = convSelection.size;
     return lightbox === 'qzone' ? `${n} 位好友 · ${fmt}` : `${n} 个会话 · ${fmt}`;
   })();
 
@@ -690,7 +793,11 @@ export function ExportView(): ReactElement {
           ? '导出 ChatLab 格式'
           : lightbox === 'qzone'
             ? '导出好友 QQ 空间'
-            : '导出聊天记录';
+            : lightbox === 'contacts'
+              ? contactScope === 'friends'
+                ? '导出好友列表'
+                : '导出群成员列表'
+              : '导出聊天记录';
 
   return (
     <div className="weq-exp">
@@ -766,6 +873,37 @@ export function ExportView(): ReactElement {
                 onChange={setConvSelection}
                 emptyText={mode === 'qzone' ? '暂无好友（仅私聊可导出空间）' : undefined}
               />
+            ) : mode === 'contacts' ? (
+              <div className="weq-exp-contacts">
+                <div className="weq-exp-contacts-switch">
+                  <Segmented<'friends' | 'group'>
+                    value={contactScope}
+                    onChange={setContactScope}
+                    options={[
+                      { value: 'friends', label: '好友', icon: <UserRound size={13} /> },
+                      { value: 'group', label: '群成员', icon: <Users size={13} /> },
+                    ]}
+                  />
+                </div>
+                {contactScope === 'friends' ? (
+                  <CategoryChips
+                    items={catItems}
+                    total={friendTotal}
+                    loading={categories.isLoading}
+                    selected={catSelection}
+                    onChange={setCatSelection}
+                  />
+                ) : (
+                  <SingleSelectPicker
+                    items={groupItems}
+                    loading={groups.isLoading}
+                    selectedId={contactGroupId}
+                    onSelect={setContactGroupId}
+                    searchPlaceholder="搜索群名称或群号"
+                    emptyText="暂无群聊"
+                  />
+                )}
+              </div>
             ) : mode === 'album' ? (
               <SingleSelectPicker
                 items={groupItems}
@@ -792,7 +930,7 @@ export function ExportView(): ReactElement {
                   ? `已选 ${convSelection.size} 个会话 · ${format.toUpperCase()} · 点击新建定时任务`
                   : '请先选择至少一个会话'}
               </span>
-            ) : isMultiConvMode ? (
+            ) : showFormatChips ? (
               <div className="weq-exp-foot-format">
                 <span className="weq-exp-foot-label">格式</span>
                 <Segmented<ExportFormat> value={format} onChange={setFormat} options={formatOptions} small />
@@ -836,6 +974,8 @@ export function ExportView(): ReactElement {
           variant={lightbox}
           headline={lightboxHeadline}
           summary={lightboxSummary}
+          // 联系人导出默认不下载头像（大群头像量大），其余沿用默认。
+          initialOptions={lightbox === 'contacts' ? { ...DEFAULT_OPTIONS, exportAvatar: false } : undefined}
           submitting={submitting}
           onPickPath={async () => {
             dialog.info('选择目录', '目录选择接口待接入，开始导出时将使用系统对话框。');
@@ -878,6 +1018,62 @@ export function ExportView(): ReactElement {
           onConfirm={(result) => void runAlbumExport(result)}
         />
       ) : null}
+    </div>
+  );
+}
+
+/** 好友分组多选 chips（导出联系人 · 好友）。空选 = 全部好友。 */
+function CategoryChips({
+  items,
+  total,
+  loading,
+  selected,
+  onChange,
+}: {
+  items: Array<{ id: number; name: string; count: number }>;
+  total: number;
+  loading: boolean;
+  selected: Set<number>;
+  onChange: (next: Set<number>) => void;
+}): ReactElement {
+  const allActive = selected.size === 0;
+  const toggle = (id: number): void => {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onChange(next);
+  };
+  return (
+    <div className="weq-exp-cats">
+      <div className="weq-exp-cats-head">
+        <strong>好友分组</strong>
+        <small>{allActive ? `全部好友 · ${total} 人` : `已选 ${selected.size} 个分组`}</small>
+      </div>
+      {loading ? (
+        <div className="weq-exp-cats-empty"><small>加载中…</small></div>
+      ) : items.length === 0 ? (
+        <div className="weq-exp-cats-empty"><small>暂无分组数据</small></div>
+      ) : (
+        <div className="weq-exp-cats-list">
+          <button
+            type="button"
+            className={`weq-exp-chip${allActive ? ' is-active' : ''}`}
+            onClick={() => onChange(new Set())}
+          >
+            全部好友 <b>{total}</b>
+          </button>
+          {items.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              className={`weq-exp-chip${selected.has(c.id) ? ' is-active' : ''}`}
+              onClick={() => toggle(c.id)}
+            >
+              {c.name} <b>{c.count}</b>
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/views/MainView.tsx
+++ b/apps/desktop/src/renderer/src/views/MainView.tsx
@@ -48,6 +48,7 @@ import {
   type Contact,
   type Conversation,
   type ConversationDrafts,
+  type ConversationHighlight,
   type ConversationPreference,
   type ConversationPreferences,
   type GroupJoinRequest,
@@ -1611,8 +1612,8 @@ export function MainView(): ReactElement {
   // Unread count per conversation id (latest msgSeq - last read seq). Filled
   // asynchronously after the recent-contact list loads / refreshes.
   const [unreadByConv, setUnreadByConv] = useState<Record<string, number>>({});
-  const [specialCareByConv, setSpecialCareByConv] = useState<
-    Record<string, { senderUid: string; msgSeq: string }>
+  const [highlightsByConv, setHighlightsByConv] = useState<
+    Record<string, ConversationHighlight[]>
   >({});
   const [groupMemberPages, setGroupMemberPages] = useState<Record<string, GroupMemberWire[]>>({});
   const [groupMemberHasMore, setGroupMemberHasMore] = useState<Record<string, boolean>>({});
@@ -1683,12 +1684,12 @@ export function MainView(): ReactElement {
       return Array.from(byId.values())
         .map((conversation) => {
           const unread = unreadByConv[conversation.id];
-          const specialCare = specialCareByConv[conversation.id] ?? null;
-          if (!unread && !specialCare) return conversation;
+          const highlights = highlightsByConv[conversation.id] ?? null;
+          if (!unread && !highlights) return conversation;
           return {
             ...conversation,
             ...(unread ? { unreadCount: unread } : {}),
-            specialCare,
+            highlights,
           };
         })
         .sort((a, b) => {
@@ -1697,7 +1698,7 @@ export function MainView(): ReactElement {
           return bTime - aTime;
         });
     },
-    [allGroups.data, contacts.data, user, unreadByConv, specialCareByConv],
+    [allGroups.data, contacts.data, user, unreadByConv, highlightsByConv],
   );
   const groupsById = useMemo(() => new Map(conversations.map((conversation) => [conversation.id, conversation])), [conversations]);
   const contactRequests = useMemo(
@@ -1808,7 +1809,7 @@ export function MainView(): ReactElement {
 
     async function loadUnread(): Promise<void> {
       const next: Record<string, number> = {};
-      const care: Record<string, { senderUid: string; msgSeq: string }> = {};
+      const highlights: Record<string, ConversationHighlight[]> = {};
       const batchSize = 12;
       for (let index = 0; index < list.length && !cancelled; index += batchSize) {
         const batch = list.slice(index, index + batchSize);
@@ -1828,9 +1829,7 @@ export function MainView(): ReactElement {
               return {
                 uid: contact.targetUid,
                 unread,
-                specialCare: info?.specialCare
-                  ? { senderUid: info.specialCare.senderUid, msgSeq: info.specialCare.msgSeq }
-                  : null,
+                highlights: (info?.highlights ?? null) as ConversationHighlight[] | null,
               };
             } catch {
               return null;
@@ -1840,12 +1839,12 @@ export function MainView(): ReactElement {
         for (const entry of counts) {
           if (!entry) continue;
           next[entry.uid] = entry.unread;
-          if (entry.specialCare) care[entry.uid] = entry.specialCare;
+          if (entry.highlights?.length) highlights[entry.uid] = entry.highlights;
         }
       }
       if (!cancelled) {
         setUnreadByConv(next);
-        setSpecialCareByConv(care);
+        setHighlightsByConv(highlights);
       }
     }
 

--- a/apps/desktop/src/renderer/src/views/MainView.tsx
+++ b/apps/desktop/src/renderer/src/views/MainView.tsx
@@ -480,8 +480,24 @@ function contactTitle(c: RecentContactWire): string {
 function previewText(preview: unknown): string | null {
   if (!preview || typeof preview !== 'object') return null;
   const p = preview as { displayText?: unknown; kind?: unknown; recallDisplayText?: unknown };
-  if (typeof p.displayText === 'string' && p.displayText.trim()) return p.displayText.trim();
+  // QQ's `displayText` is unreliable for element-only messages: a lone face /
+  // sticker often stores an *invisible* sysface control marker that renders as a
+  // blank conversation-list row. Treat "no visible character" as empty so we
+  // fall back to the kind-derived bracket label ([表情] / [图片] …).
+  if (typeof p.displayText === 'string' && hasVisibleText(p.displayText)) {
+    return p.displayText.trim();
+  }
   return previewFallbackByKind(p);
+}
+
+/** True when a string has at least one visible (non-control, non-space) char. */
+function hasVisibleText(s: string): boolean {
+  // Visible = any char that is not a C0/C1 control char (QQ sysface markers) or whitespace.
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c > 0x20 && c !== 0x7f && !(c >= 0x80 && c <= 0x9f)) return true;
+  }
+  return false;
 }
 
 /**

--- a/apps/desktop/src/renderer/src/views/MainView.tsx
+++ b/apps/desktop/src/renderer/src/views/MainView.tsx
@@ -32,6 +32,7 @@ import { RailAccountFooter } from '../components/RailAccountFooter';
 import { SettingsDialog } from '../components/SettingsDialog';
 import { GroupAlbumDialog } from '../components/GroupAlbumDialog';
 import { GroupAnalyticsDialog } from '../components/GroupAnalyticsDialog';
+import { MemberProfileCard } from '../components/MemberProfileCard';
 import { BuddyAnalyticsDialog } from '../components/BuddyAnalyticsDialog';
 import { AddMessageModal } from '../components/compose/AddMessageModal';
 import { RelationGraphView } from '../components/relationGraph/RelationGraphView';
@@ -144,6 +145,8 @@ type RecentContactWire = {
   senderRemark: string;
   targetAvatar: string;
   targetRemark: string;
+  /** 41220 — message-notify level. 1 = notify normally; else (observed 4) 免打扰/muted. */
+  notifyLevel: number;
 };
 
 type MessageWire = {
@@ -765,11 +768,25 @@ function levelNameFor(levelConfigs: Array<{ level: number; levelName: string }>,
   return levelConfigs.find((item) => item.level === bracket)?.levelName || `Lv${level}`;
 }
 
+/**
+ * Derive the 免打扰/muted flag from `recent_contact` column 41220.
+ * Observed values: 1 = notify normally, 4 = muted. Treat 0/1 as "notify"
+ * (0 = unset) and anything else (2/3/4 — QQ's various push-restriction modes)
+ * as muted, so the conversation shows the grey badge + disabled-bell indicator.
+ */
+function mutedFromNotifyLevel(notifyLevel: number | undefined): boolean {
+  return notifyLevel !== undefined && notifyLevel !== 0 && notifyLevel !== 1;
+}
+
 function contactToConversation(c: RecentContactWire, user: User): Conversation | null {
   const kind = chatTypeKind(c.chatType);
   const title = contactTitle(c);
   const preview = previewText(c.preview);
   const updatedAt = toIsoTime(c.sendTime);
+  const preference: ConversationPreference = {
+    ...fallbackPreference,
+    muted: mutedFromNotifyLevel(c.notifyLevel),
+  };
   const lastMessage = {
     id: `preview:${c.targetUid}:${c.sendTime}`,
     senderId: c.senderUid || null,
@@ -795,7 +812,7 @@ function contactToConversation(c: RecentContactWire, user: User): Conversation |
       otherUser,
       group: null,
       members: [],
-      preference: fallbackPreference,
+      preference,
       unreadCount: 0,
       lastMessage,
       chatType: c.chatType,
@@ -819,7 +836,7 @@ function contactToConversation(c: RecentContactWire, user: User): Conversation |
         role: 'member',
       },
       members: [{ ...user, role: 'member', joinedAt: updatedAt }],
-      preference: fallbackPreference,
+      preference,
       unreadCount: 0,
       lastMessage,
     };
@@ -835,21 +852,27 @@ function contactToConversation(c: RecentContactWire, user: User): Conversation |
  * the logged-in account's uin, which QQ NT sets on every outbound message in
  * both c2c and group chats.
  *
- * The legacy `data.isSender === true` fallback exists for c2c messages where
- * `senderUin` is missing (historical receive paths). It is GROUP-UNSAFE: a
- * group `multiMsg` (合并转发) element carries sub-messages whose `isSender`
- * reflects whether *the original sender of that sub-message* was self, not
- * whether the carrier message is self. Reading isSender at the top level
- * misclassifies anyone forwarding a chat that included one of your messages
- * as "sent by me". So we only use the fallback in c2c conversations.
+ * The legacy `data.isSender === true` fallback exists ONLY for messages where
+ * `senderUin` is missing (historical receive paths). It is UNSAFE to trust
+ * otherwise: a `multiMsg` (合并转发) carrier element itself carries
+ * `isSender=true` in the local DB, and that flag does NOT reflect the carrier
+ * message's own direction. Reading it at the top level misclassifies a forward
+ * the peer sent you as "sent by me" (both c2c and group). So whenever a valid
+ * `senderUin` is present we decide direction from it alone and never consult
+ * `isSender`; the fallback is reached only when `senderUin` is absent/'0'.
  */
 function isMineMessage(message: MessageWire, conversation: Conversation, user: User): boolean {
-  if (message.senderUin && message.senderUin === user.identityValue) return true;
-  if (conversation.type !== 'direct') return false;
   // 数据线：senderUin 是自己（各设备同号），无法区分方向；约定 PC 伪 uid = 本机，
-  // 由它发出的算"我发的"，手机/平板发来的算对端。
+  // 由它发出的算"我发的"，手机/平板发来的算对端。这些伪 uid 只在数据线会话命中，
+  // 对普通好友/群成员 uid 返回 false，故可安全地放在最前面。
   if (isDatalineSelfUid(message.senderUid)) return true;
   if (datalineName(message.senderUid)) return false;
+  // senderUin 有效（存在且非哨兵 '0'）时以它为准判定方向，不再信任 element.isSender。
+  if (message.senderUin && message.senderUin !== '0') {
+    return message.senderUin === user.identityValue;
+  }
+  // senderUin 缺失时才 fallback 到 element 标志（旧/迁移消息兜底），仅限私聊。
+  if (conversation.type !== 'direct') return false;
   return message.elements.some((element) => {
     const data = (element as RenderElementWire | null)?.data;
     return data?.isSender === true;
@@ -1507,7 +1530,11 @@ export function MainView(): ReactElement {
     peerUid: string;
     peerName: string;
   } | null>(null);
-  
+  const [memberCard, setMemberCard] = useState<{
+    member: any;
+    anchor: { x: number; y: number };
+  } | null>(null);
+
   const [editorState, setEditorState] = useState<{ msgId: string, elements: any[] } | null>(null);
   const [addMessageConv, setAddMessageConv] = useState<Conversation | null>(null);
 
@@ -1562,6 +1589,13 @@ export function MainView(): ReactElement {
     setAddMessageConv(conversation);
   }, []);
 
+  const handleOpenGroupMember = useCallback(
+    (member: any, anchor: { x: number; y: number }) => {
+      setMemberCard({ member, anchor });
+    },
+    [],
+  );
+
   const handleOpenBuddyAnalytics = useCallback((conversation: Extract<Conversation, { type: 'direct' }>) => {
     setBuddyAnalyticsDialog({
       peerUid: conversation.otherUser.id,
@@ -1577,6 +1611,9 @@ export function MainView(): ReactElement {
   // Unread count per conversation id (latest msgSeq - last read seq). Filled
   // asynchronously after the recent-contact list loads / refreshes.
   const [unreadByConv, setUnreadByConv] = useState<Record<string, number>>({});
+  const [specialCareByConv, setSpecialCareByConv] = useState<
+    Record<string, { senderUid: string; msgSeq: string }>
+  >({});
   const [groupMemberPages, setGroupMemberPages] = useState<Record<string, GroupMemberWire[]>>({});
   const [groupMemberHasMore, setGroupMemberHasMore] = useState<Record<string, boolean>>({});
   const [groupMemberLoading, setGroupMemberLoading] = useState<Record<string, boolean>>({});
@@ -1646,7 +1683,13 @@ export function MainView(): ReactElement {
       return Array.from(byId.values())
         .map((conversation) => {
           const unread = unreadByConv[conversation.id];
-          return unread ? { ...conversation, unreadCount: unread } : conversation;
+          const specialCare = specialCareByConv[conversation.id] ?? null;
+          if (!unread && !specialCare) return conversation;
+          return {
+            ...conversation,
+            ...(unread ? { unreadCount: unread } : {}),
+            specialCare,
+          };
         })
         .sort((a, b) => {
           const aTime = Date.parse(a.updatedAt);
@@ -1654,7 +1697,7 @@ export function MainView(): ReactElement {
           return bTime - aTime;
         });
     },
-    [allGroups.data, contacts.data, user, unreadByConv],
+    [allGroups.data, contacts.data, user, unreadByConv, specialCareByConv],
   );
   const groupsById = useMemo(() => new Map(conversations.map((conversation) => [conversation.id, conversation])), [conversations]);
   const contactRequests = useMemo(
@@ -1765,6 +1808,7 @@ export function MainView(): ReactElement {
 
     async function loadUnread(): Promise<void> {
       const next: Record<string, number> = {};
+      const care: Record<string, { senderUid: string; msgSeq: string }> = {};
       const batchSize = 12;
       for (let index = 0; index < list.length && !cancelled; index += batchSize) {
         const batch = list.slice(index, index + batchSize);
@@ -1781,17 +1825,28 @@ export function MainView(): ReactElement {
               const latest = BigInt(contact.msgSeq || '0');
               const read = info?.msgSeq ? BigInt(info.msgSeq) : 0n;
               const unread = latest > read ? Number(latest - read) : 0;
-              return [contact.targetUid, unread] as const;
+              return {
+                uid: contact.targetUid,
+                unread,
+                specialCare: info?.specialCare
+                  ? { senderUid: info.specialCare.senderUid, msgSeq: info.specialCare.msgSeq }
+                  : null,
+              };
             } catch {
               return null;
             }
           }),
         );
         for (const entry of counts) {
-          if (entry) next[entry[0]] = entry[1];
+          if (!entry) continue;
+          next[entry.uid] = entry.unread;
+          if (entry.specialCare) care[entry.uid] = entry.specialCare;
         }
       }
-      if (!cancelled) setUnreadByConv(next);
+      if (!cancelled) {
+        setUnreadByConv(next);
+        setSpecialCareByConv(care);
+      }
     }
 
     void loadUnread();
@@ -2747,6 +2802,7 @@ export function MainView(): ReactElement {
                 onOpenGroupAnnouncements={handleOpenGroupAnnouncements}
                 onOpenGroupAnalytics={handleOpenGroupAnalytics}
                 onOpenBuddyAnalytics={handleOpenBuddyAnalytics}
+                onOpenGroupMember={handleOpenGroupMember}
                 onAddMessage={handleAddMessage}
               />
             </div>
@@ -2794,6 +2850,13 @@ export function MainView(): ReactElement {
           peerUid={buddyAnalyticsDialog.peerUid}
           peerName={buddyAnalyticsDialog.peerName}
           onClose={() => setBuddyAnalyticsDialog(null)}
+        />
+      ) : null}
+      {memberCard ? (
+        <MemberProfileCard
+          member={memberCard.member}
+          anchor={memberCard.anchor}
+          onClose={() => setMemberCard(null)}
         />
       ) : null}
       {addMessageConv ? (

--- a/apps/desktop/src/renderer/src/views/MainView.tsx
+++ b/apps/desktop/src/renderer/src/views/MainView.tsx
@@ -35,6 +35,8 @@ import { GroupAnalyticsDialog } from '../components/GroupAnalyticsDialog';
 import { MemberProfileCard } from '../components/MemberProfileCard';
 import { BuddyAnalyticsDialog } from '../components/BuddyAnalyticsDialog';
 import { AddMessageModal } from '../components/compose/AddMessageModal';
+import { DeletedMessagesModal } from '../components/compose/DeletedMessagesModal';
+import { loadHiddenMessageIds, saveHiddenMessageIds } from '../im-template/template/hiddenMessages';
 import { RelationGraphView } from '../components/relationGraph/RelationGraphView';
 import { AgentLabView } from './AgentLabView';
 import { ExportView } from './ExportView';
@@ -1538,6 +1540,13 @@ export function MainView(): ReactElement {
 
   const [editorState, setEditorState] = useState<{ msgId: string, elements: any[] } | null>(null);
   const [addMessageConv, setAddMessageConv] = useState<Conversation | null>(null);
+  // "查看删除消息" panel: which conversation is open, its fetched deleted rows,
+  // and a bump counter that tells ChatPane to re-read its local hidden set after
+  // a restore (so the message reappears in the live chat immediately).
+  const [deletedConv, setDeletedConv] = useState<Conversation | null>(null);
+  const [deletedWires, setDeletedWires] = useState<MessageWire[]>([]);
+  const [deletedLoading, setDeletedLoading] = useState(false);
+  const [hiddenReloadKey, setHiddenReloadKey] = useState(0);
 
   const handleEditRaw = useCallback(async (message: Message) => {
     try {
@@ -1553,9 +1562,9 @@ export function MainView(): ReactElement {
   const handleSaveRaw = useCallback(async (elements: any[]) => {
     if (!editorState) return;
     try {
-        const success = await client.account.updateElements.mutate({ 
-            msgId: editorState.msgId, 
-            elements 
+        const success = await client.account.updateElements.mutate({
+            msgId: editorState.msgId,
+            elements
         });
         if (success) {
             void refreshWindow();
@@ -1565,6 +1574,24 @@ export function MainView(): ReactElement {
         throw e;
     }
   }, [editorState, refreshWindow]);
+
+  const handleDeleteMessage = useCallback(async (message: Message) => {
+    try {
+        await client.account.deleteMessage.mutate({ msgId: message.id });
+    } catch (e) {
+        console.error('[MainView] Failed to delete message:', e);
+    }
+  }, []);
+
+  const handleHardDeleteMessage = useCallback(async (message: Message) => {
+    try {
+        await client.account.hardDeleteMessage.mutate({ msgId: message.id });
+        // Row is physically gone — refresh so the window reflects the DB.
+        void refreshWindow();
+    } catch (e) {
+        console.error('[MainView] Failed to hard-delete message:', e);
+    }
+  }, [refreshWindow]);
 
   const handleOpenGroupAlbums = useCallback((conversation: Extract<Conversation, { type: 'group' }>) => {
     setAlbumDialog({
@@ -1589,6 +1616,57 @@ export function MainView(): ReactElement {
   const handleAddMessage = useCallback((conversation: Conversation) => {
     setAddMessageConv(conversation);
   }, []);
+
+  /** kind + conversation key (peer uid / group code) used by the msg endpoints. */
+  const convFetchKey = useCallback(
+    (c: Conversation): { kind: 'c2c' | 'group'; conv: string } =>
+      c.type === 'group'
+        ? { kind: 'group', conv: c.group.identityValue }
+        : { kind: 'c2c', conv: c.otherUser.id },
+    [],
+  );
+
+  const loadDeletedMessages = useCallback(
+    async (c: Conversation): Promise<void> => {
+      const { kind, conv } = convFetchKey(c);
+      setDeletedLoading(true);
+      try {
+        const rows = await client.account.deletedMessages.query({ kind, conv });
+        setDeletedWires(rows.map(toMessageWire));
+      } catch (e) {
+        console.error('[MainView] Failed to load deleted messages:', e);
+        setDeletedWires([]);
+      } finally {
+        setDeletedLoading(false);
+      }
+    },
+    [convFetchKey],
+  );
+
+  const handleViewDeleted = useCallback(
+    (conversation: Conversation) => {
+      setDeletedWires([]);
+      setDeletedConv(conversation);
+      void loadDeletedMessages(conversation);
+    },
+    [loadDeletedMessages],
+  );
+
+  const handleRestoreMessage = useCallback(
+    async (msgId: string): Promise<void> => {
+      await client.account.restoreMessage.mutate({ msgId });
+      if (deletedConv) {
+        // Delete had added this id to the conversation's local hidden set; drop
+        // it so the live chat re-shows the row, then nudge ChatPane to re-read.
+        const ids = loadHiddenMessageIds(deletedConv.id);
+        if (ids.delete(msgId)) saveHiddenMessageIds(deletedConv.id, ids);
+        setHiddenReloadKey((k) => k + 1);
+        await loadDeletedMessages(deletedConv);
+      }
+      void refreshWindow();
+    },
+    [deletedConv, loadDeletedMessages, refreshWindow],
+  );
 
   const handleOpenGroupMember = useCallback(
     (member: any, anchor: { x: number; y: number }) => {
@@ -2047,6 +2125,17 @@ export function MainView(): ReactElement {
         messageToTemplate(message, selectedConversation, user, memberMap)
       );
   }, [loadedMessageWires, selectedConversation, user, currentGroupMembers]);
+
+  // Deleted messages built through the SAME template pipeline as the live chat,
+  // so the panel's bubbles match exactly. The panel only opens for the currently
+  // selected conversation, so `currentGroupMembers` is the right member source.
+  const deletedTemplateMessages = useMemo(() => {
+    if (!deletedConv) return [];
+    const memberMap = new Map(currentGroupMembers.map((m) => [m.id, m]));
+    return deletedWires
+      .filter((message) => isRenderableMessage(message))
+      .map((message) => messageToTemplate(message, deletedConv, user, memberMap));
+  }, [deletedWires, deletedConv, user, currentGroupMembers]);
 
   const activeConversation = useMemo(() => {
     if (!selectedConversation) return undefined;
@@ -2797,12 +2886,16 @@ export function MainView(): ReactElement {
                 onDraftClear={(_conversationId) => updateDraft(_conversationId, '')}
                 onBackConversation={shell.backConversation}
                 onEditRaw={handleEditRaw}
+                onDeleteMessage={handleDeleteMessage}
+                onHardDeleteMessage={handleHardDeleteMessage}
                 onOpenGroupAlbums={handleOpenGroupAlbums}
                 onOpenGroupAnnouncements={handleOpenGroupAnnouncements}
                 onOpenGroupAnalytics={handleOpenGroupAnalytics}
                 onOpenBuddyAnalytics={handleOpenBuddyAnalytics}
                 onOpenGroupMember={handleOpenGroupMember}
                 onAddMessage={handleAddMessage}
+                onViewDeleted={handleViewDeleted}
+                hiddenReloadKey={hiddenReloadKey}
               />
             </div>
             <OverlayScrollbar
@@ -2865,6 +2958,20 @@ export function MainView(): ReactElement {
           selfUid={selfProfile.data?.uid}
           onClose={() => setAddMessageConv(null)}
           onInserted={() => void refreshWindow()}
+        />
+      ) : null}
+      {deletedConv ? (
+        <DeletedMessagesModal
+          conversation={deletedConv}
+          user={user}
+          messages={deletedTemplateMessages}
+          renderers={messageRenderers}
+          loading={deletedLoading}
+          onRestore={handleRestoreMessage}
+          onClose={() => {
+            setDeletedConv(null);
+            setDeletedWires([]);
+          }}
         />
       ) : null}
       </ConvContext.Provider>

--- a/apps/desktop/src/renderer/src/views/cache/AvatarExplorer.tsx
+++ b/apps/desktop/src/renderer/src/views/cache/AvatarExplorer.tsx
@@ -14,9 +14,10 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
-import { Users, UsersRound, Image as ImageIcon, RefreshCw } from 'lucide-react';
+import { Users, UsersRound, Image as ImageIcon, RefreshCw, Calculator } from 'lucide-react';
 import type { AvatarEntry, AvatarScope, AvatarScopeInfo } from '@weq/service';
 import { trpc, client } from '../../trpc/client';
+import { AvatarPathDialog } from './AvatarPathDialog';
 
 const PAGE = 120;
 
@@ -57,6 +58,7 @@ export function AvatarExplorer(): ReactElement {
   );
 
   const [active, setActive] = useState<AvatarScope>('user');
+  const [toolOpen, setToolOpen] = useState(false);
 
   // Auto-select the first present scope once the summary lands (if the current
   // one turned out empty).
@@ -86,9 +88,19 @@ export function AvatarExplorer(): ReactElement {
         {scopes.isLoading && scopeList.length === 0 ? (
           <span className="weq-cache-avatar-loading">扫描头像缓存中…</span>
         ) : null}
+        <button
+          type="button"
+          className="weq-cache-avatar-tool"
+          onClick={() => setToolOpen(true)}
+          title="输入 QQ 号 / 群号，计算其头像缓存路径"
+        >
+          <Calculator size={14} />
+          <span>算路径</span>
+        </button>
       </div>
 
       <AvatarGrid key={active} scope={active} />
+      {toolOpen ? <AvatarPathDialog onClose={() => setToolOpen(false)} /> : null}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/views/cache/AvatarPathDialog.tsx
+++ b/apps/desktop/src/renderer/src/views/cache/AvatarPathDialog.tsx
@@ -1,0 +1,218 @@
+/**
+ * 头像缓存路径计算器 — enter a QQ number, see exactly where QQ cached that
+ * avatar on disk, and WHY (the hash derivation is shown as the rationale).
+ *
+ *   friend:  uin --profile_info_v6--> uid ┐
+ *   group:   uin == uid (numeric)         ├─> hash = md5(md5(md5(uid)+uid)+uid)
+ *                                         ┘   path = avatar/<scope>/<hash[:2]>/[b_|s_]<hash>
+ *
+ * The path + on-disk presence come from `account.avatarResource.computePath`;
+ * the preview points at the same `weq-media://avatar` protocol the grid uses.
+ */
+
+import { useCallback, useState, type ReactElement } from 'react';
+import { X, Search, User, Users, Copy, Check } from 'lucide-react';
+import type { AvatarPathProbe } from '@weq/service';
+import { Modal } from '../../components/Dialog';
+import { client } from '../../trpc/client';
+
+type Kind = 'user' | 'group';
+
+function fmtBytes(bytes: number): string {
+  if (!bytes) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let n = bytes;
+  let i = 0;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i += 1;
+  }
+  return `${n.toFixed(n >= 10 || i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+/** weq-media URL for the resolved avatar (by hash — same as the grid). */
+function previewSrc(probe: AvatarPathProbe, variant: 'big' | 'small'): string {
+  return `weq-media://avatar?scope=${probe.scope}&hash=${probe.hash}&v=${variant}`;
+}
+
+export function AvatarPathDialog({ onClose }: { onClose: () => void }): ReactElement {
+  const [kind, setKind] = useState<Kind>('user');
+  const [qq, setQq] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [probe, setProbe] = useState<AvatarPathProbe | null>(null);
+
+  const run = useCallback(async (): Promise<void> => {
+    const trimmed = qq.trim();
+    if (!/^\d+$/.test(trimmed)) {
+      setError('请输入纯数字的 QQ 号 / 群号');
+      setProbe(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await client.account.avatarResource.computePath.query({ kind, qq: trimmed });
+      setProbe(result);
+      if (!result.resolved) {
+        setError(
+          kind === 'user'
+            ? '未在 profile_info_v6 找到该 QQ 的资料，无法解析 uid（不是好友或资料未缓存）'
+            : '无效的群号',
+        );
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setProbe(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [kind, qq]);
+
+  return (
+    <Modal onClose={onClose} labelledBy="weq-avpath-title" width={452}>
+      <div className="weq-avpath">
+        <div className="weq-avpath-head">
+          <h3 id="weq-avpath-title" className="weq-avpath-title">
+            头像缓存路径计算器
+          </h3>
+          <button className="weq-dialog-x" onClick={onClose} aria-label="关闭">
+            <X size={16} strokeWidth={1.9} aria-hidden />
+          </button>
+        </div>
+
+        {/* kind toggle + input */}
+        <div className="weq-avpath-form">
+          <div className="weq-avpath-seg">
+            <button
+              type="button"
+              className={`weq-avpath-segbtn${kind === 'user' ? ' is-on' : ''}`}
+              onClick={() => setKind('user')}
+            >
+              <User size={14} /> 好友
+            </button>
+            <button
+              type="button"
+              className={`weq-avpath-segbtn${kind === 'group' ? ' is-on' : ''}`}
+              onClick={() => setKind('group')}
+            >
+              <Users size={14} /> 群聊
+            </button>
+          </div>
+          <input
+            className="weq-avpath-input"
+            value={qq}
+            inputMode="numeric"
+            placeholder={kind === 'user' ? '输入 QQ 号' : '输入群号'}
+            onChange={(e) => setQq(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void run();
+            }}
+          />
+          <button className="weq-action-primary weq-avpath-go" onClick={() => void run()} disabled={loading}>
+            <Search size={14} /> {loading ? '计算中…' : '计算'}
+          </button>
+        </div>
+
+        {/* algorithm — shown as the rationale, always visible */}
+        <div className="weq-avpath-algo">
+          <span className="weq-avpath-algo-label">算法依据</span>
+          <code className="weq-avpath-algo-code">
+            hash = md5( md5( md5(uid) + uid ) + uid )
+          </code>
+          <code className="weq-avpath-algo-code">
+            path = avatar/&lt;scope&gt;/&lt;hash 前两位&gt;/（b_大图 | s_缩略图）+ hash
+          </code>
+          <p className="weq-avpath-algo-note">
+            好友：uin 经 <b>profile_info_v6</b> 表查出 uid；群聊：uin 即 uid（纯数字）。三重 MD5 均为十六进制字符串拼接。
+          </p>
+        </div>
+
+        {error ? <div className="weq-avpath-error">{error}</div> : null}
+
+        {probe && probe.resolved ? <ProbeResult probe={probe} /> : null}
+      </div>
+    </Modal>
+  );
+}
+
+function ProbeResult({ probe }: { probe: AvatarPathProbe }): ReactElement {
+  const onDisk = probe.hasBig || probe.hasSmall;
+  const [variant, setVariant] = useState<'big' | 'small'>(probe.hasBig ? 'big' : 'small');
+
+  return (
+    <div className="weq-avpath-result">
+      <div className="weq-avpath-preview">
+        {onDisk ? (
+          <img
+            src={previewSrc(probe, variant)}
+            alt={probe.hash}
+            onError={() => {
+              if (variant === 'big' && probe.hasSmall) setVariant('small');
+            }}
+          />
+        ) : (
+          <span className="weq-avpath-preview-empty">本地无缓存</span>
+        )}
+      </div>
+
+      <div className="weq-avpath-fields">
+        <Field label="uid">
+          <span className="weq-avpath-mono">{probe.uid}</span>
+          {probe.nick ? <em className="weq-avpath-nick">（{probe.nick}）</em> : null}
+        </Field>
+        <Field label="hash">
+          <span className="weq-avpath-mono weq-avpath-hash">{probe.hash}</span>
+        </Field>
+        <PathRow label="大图" rel={probe.bigRel} on={probe.hasBig} bytes={probe.bigBytes} />
+        <PathRow label="缩略图" rel={probe.smallRel} on={probe.hasSmall} bytes={probe.smallBytes} />
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }): ReactElement {
+  return (
+    <div className="weq-avpath-field">
+      <span className="weq-avpath-field-label">{label}</span>
+      <div className="weq-avpath-field-val">{children}</div>
+    </div>
+  );
+}
+
+function PathRow({
+  label,
+  rel,
+  on,
+  bytes,
+}: {
+  label: string;
+  rel: string;
+  on: boolean;
+  bytes: number;
+}): ReactElement {
+  const [copied, setCopied] = useState(false);
+  const copy = useCallback(() => {
+    void navigator.clipboard?.writeText(rel).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    });
+  }, [rel]);
+
+  return (
+    <div className="weq-avpath-field">
+      <span className="weq-avpath-field-label">
+        {label}
+        <span className={`weq-avpath-badge is-${on ? 'on' : 'off'}`}>
+          {on ? fmtBytes(bytes) : '缺失'}
+        </span>
+      </span>
+      <div className="weq-avpath-field-val weq-avpath-pathrow">
+        <span className="weq-avpath-mono weq-avpath-path">{rel}</span>
+        <button className="weq-avpath-copy" onClick={copy} title="复制路径" aria-label="复制路径">
+          {copied ? <Check size={13} /> : <Copy size={13} />}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/views/cache/CacheView.tsx
+++ b/apps/desktop/src/renderer/src/views/cache/CacheView.tsx
@@ -26,6 +26,7 @@ import {
   PanelLeftClose,
   PanelLeftOpen,
   ChartPie,
+  Trash2,
 } from 'lucide-react';
 import { DbExplorer } from './DbExplorer';
 import { AvatarExplorer } from './AvatarExplorer';
@@ -37,6 +38,7 @@ import { FileDirExplorer } from './FileDirExplorer';
 import { DownloadFileExplorer } from './DownloadFileExplorer';
 import { FlatMediaExplorer, MonthMediaExplorer, VoiceExplorer } from './MediaResourceExplorers';
 import { ResourceAnalyticsDialog } from './ResourceAnalyticsDialog';
+import { ResourceCleanupDialog } from './ResourceCleanupDialog';
 import '../../styles/cache.css';
 
 /** 一个缓存资源分类。`ready` 为 false 时右侧渲染占位空状态。 */
@@ -70,6 +72,8 @@ export function CacheView(): ReactElement {
   const [catsCollapsed, setCatsCollapsed] = useState(false);
   // 整体分析弹窗（遍历全部资源目录统计）。
   const [showAnalytics, setShowAnalytics] = useState(false);
+  // 清理释放弹窗（删除本地缓存以释放磁盘空间）。
+  const [showCleanup, setShowCleanup] = useState(false);
   const activeCategory = CATEGORIES.find((c) => c.id === active) ?? CATEGORIES[0]!;
 
   return (
@@ -95,6 +99,15 @@ export function CacheView(): ReactElement {
           >
             <ChartPie size={16} />
           </button>
+          <button
+            type="button"
+            className="weq-cache-analyze-rail weq-cache-clean-rail"
+            onClick={() => setShowCleanup(true)}
+            title="清理释放"
+            aria-label="清理释放"
+          >
+            <Trash2 size={16} />
+          </button>
         </div>
       ) : (
         <nav className="weq-cache-cats" aria-label="缓存资源分类">
@@ -110,14 +123,24 @@ export function CacheView(): ReactElement {
               <PanelLeftClose size={16} />
             </button>
           </div>
-          <button
-            type="button"
-            className="weq-cache-analyze-btn"
-            onClick={() => setShowAnalytics(true)}
-          >
-            <ChartPie size={16} />
-            <span>整体分析</span>
-          </button>
+          <div className="weq-cache-actions">
+            <button
+              type="button"
+              className="weq-cache-analyze-btn"
+              onClick={() => setShowAnalytics(true)}
+            >
+              <ChartPie size={16} />
+              <span>整体分析</span>
+            </button>
+            <button
+              type="button"
+              className="weq-cache-analyze-btn weq-cache-clean-btn"
+              onClick={() => setShowCleanup(true)}
+            >
+              <Trash2 size={16} />
+              <span>清理释放</span>
+            </button>
+          </div>
           <div className="weq-cache-cats-body">
             {CATEGORIES.map((c) => (
               <button
@@ -171,6 +194,7 @@ export function CacheView(): ReactElement {
       </section>
 
       <ResourceAnalyticsDialog open={showAnalytics} onClose={() => setShowAnalytics(false)} />
+      <ResourceCleanupDialog open={showCleanup} onClose={() => setShowCleanup(false)} />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/views/cache/ResourceAnalyticsDialog.tsx
+++ b/apps/desktop/src/renderer/src/views/cache/ResourceAnalyticsDialog.tsx
@@ -3,11 +3,11 @@
  * charts the totals. The scan is the slow part (each file is `stat`-ed for its
  * size), so it runs ONE tree at a time via `mediaResource.analyzeTree`, showing a
  * progress banner + per-category cards that fill in as each tree finishes. The
- * cross-category charts (size/count donuts, the by-month bars, the 源文件/缩略图
- * split) render once the whole sweep completes.
+ * cross-category charts (the ranked category bars, the by-month bars, the
+ * 源文件/缩略图 split) render once the whole sweep completes.
  *
- * Visuals reuse the shared {@link DonutChart} (theme-aware, dependency-free) plus
- * a small inline monthly-bar chart; everything follows the picked accent.
+ * Visuals are dependency-free inline bar charts whose colours all come from
+ * {@link ACCENT_SERIES}, so everything follows 设置里的主题色.
  */
 
 import { useCallback, useEffect, useRef, useState, type ReactElement } from 'react';
@@ -29,19 +29,23 @@ import {
 } from 'lucide-react';
 import type { ResourceStat, ResourceTreeKey } from '@weq/service';
 import { client } from '../../trpc/client';
-import { DonutChart, formatNumber } from '../../components/analyticsCharts';
+import { ACCENT_MUTED, ACCENT_SERIES, formatNumber } from '../../components/analyticsCharts';
 import { fmtBytes } from './FileResourceShared';
 
-/** The trees to scan, in a stable order (also fixes each category's colour). */
+/**
+ * The trees to scan, in a stable order (also fixes each category's colour).
+ * Colours come from {@link ACCENT_SERIES} so every slice follows 设置里的主题色
+ * — cohesive shades of the accent rather than a clashing rainbow.
+ */
 const TREES: Array<{ key: ResourceTreeKey; label: string; icon: ReactElement; color: string }> = [
-  { key: 'pic', label: '图片', icon: <ImageIcon size={15} />, color: 'var(--weq-accent-effective)' },
-  { key: 'video', label: '视频', icon: <Film size={15} />, color: 'color-mix(in srgb, var(--weq-accent-effective) 60%, #8b5cf6)' },
-  { key: 'ptt', label: '语音', icon: <AudioLines size={15} />, color: '#22c55e' },
-  { key: 'emoji', label: '表情', icon: <Smile size={15} />, color: '#f59e0b' },
-  { key: 'avatar', label: '头像', icon: <ImageIcon size={15} />, color: '#ec4899' },
-  { key: 'photoWall', label: '图片墙', icon: <Images size={15} />, color: '#06b6d4' },
-  { key: 'qzone', label: 'QQ空间', icon: <Cloud size={15} />, color: '#f43f5e' },
-  { key: 'file', label: '文件', icon: <Folder size={15} />, color: '#94a3b8' },
+  { key: 'pic', label: '图片', icon: <ImageIcon size={15} />, color: ACCENT_SERIES[0] },
+  { key: 'video', label: '视频', icon: <Film size={15} />, color: ACCENT_SERIES[1] },
+  { key: 'ptt', label: '语音', icon: <AudioLines size={15} />, color: ACCENT_SERIES[2] },
+  { key: 'emoji', label: '表情', icon: <Smile size={15} />, color: ACCENT_SERIES[3] },
+  { key: 'avatar', label: '头像', icon: <ImageIcon size={15} />, color: ACCENT_SERIES[4] },
+  { key: 'photoWall', label: '图片墙', icon: <Images size={15} />, color: ACCENT_SERIES[5] },
+  { key: 'qzone', label: 'QQ空间', icon: <Cloud size={15} />, color: ACCENT_SERIES[6] },
+  { key: 'file', label: '文件', icon: <Folder size={15} />, color: ACCENT_SERIES[7] },
 ];
 
 function labelOf(key: ResourceTreeKey): string {
@@ -222,54 +226,31 @@ export function ResourceAnalyticsDialog({
             />
           </div>
 
-          {/* Cross-category donuts (need the full sweep). */}
-          <div className="weq-ra-charts">
-            <ChartCard title="各分类占用大小">
-              {done && present.length > 0 ? (
-                <DonutChart
-                  segments={present
-                    .slice()
-                    .sort((a, b) => b.bytes - a.bytes)
-                    .map((s) => ({ label: labelOf(s.key), value: s.bytes, color: colorOf(s.key) }))}
-                  centerLabel={fmtBytes(totals.bytes)}
-                  centerSub="总大小"
-                />
-              ) : (
-                <ChartWaiting scanning={scanningKey !== null} />
-              )}
-            </ChartCard>
+          {/* Cross-category ranking — one bar chart covers both 大小 and 数量
+              (toggle), so every category name shows in full without the cramped
+              legend the old donuts had. */}
+          <ChartCard title="各分类分布" wide>
+            {done && present.length > 0 ? (
+              <CategoryBars stats={present} totals={totals} />
+            ) : (
+              <ChartWaiting scanning={scanningKey !== null} />
+            )}
+          </ChartCard>
 
-            <ChartCard title="各分类文件数量">
-              {done && present.length > 0 ? (
-                <DonutChart
-                  segments={present
-                    .slice()
-                    .sort((a, b) => b.files - a.files)
-                    .map((s) => ({ label: labelOf(s.key), value: s.files, color: colorOf(s.key) }))}
-                  centerLabel={formatNumber(totals.files)}
-                  centerSub="总数量"
-                />
-              ) : (
-                <ChartWaiting scanning={scanningKey !== null} />
-              )}
-            </ChartCard>
-
-            <ChartCard title="源文件 / 缩略图 占比">
-              {done && totals.files > 0 ? (
-                <DonutChart
-                  segments={[
-                    { label: '源文件', value: totals.ori.bytes, color: 'var(--weq-accent-effective)' },
-                    { label: '缩略图', value: totals.thumb.bytes, color: '#f59e0b' },
-                    { label: '其它', value: totals.other.bytes, color: '#94a3b8' },
-                  ]}
-                  centerLabel={fmtBytes(totals.ori.bytes + totals.thumb.bytes)}
-                  centerSub="原图+缩略图"
-                />
-              ) : (
-                <ChartWaiting scanning={scanningKey !== null} />
-              )}
-            </ChartCard>
-          </div>
+          {/* 源文件 / 缩略图 占比 as a slim 100% stacked bar. */}
+          <ChartCard title="源文件 / 缩略图 占比" wide>
+            {done && totals.files > 0 ? (
+              <ShareBar
+                segments={[
+                  { label: '源文件', bytes: totals.ori.bytes, files: totals.ori.files, color: ACCENT_SERIES[0] },
+                  { label: '缩略图', bytes: totals.thumb.bytes, files: totals.thumb.files, color: ACCENT_SERIES[3] },
+                  { label: '其它', bytes: totals.other.bytes, files: totals.other.files, color: ACCENT_MUTED },
+                ]}
+              />
+            ) : (
+              <ChartWaiting scanning={scanningKey !== null} />
+            )}
+          </ChartCard>
 
           {/* By-month bars. */}
           <ChartCard title="按时间分布（文件修改月份）" wide>
@@ -382,6 +363,113 @@ function ChartWaiting({ scanning }: { scanning: boolean }): ReactElement {
       ) : (
         <span>暂无数据</span>
       )}
+    </div>
+  );
+}
+
+/**
+ * Ranked horizontal bars over the scanned categories. A 大小/数量 toggle switches
+ * which metric drives the bar length + sort order, while BOTH values stay on
+ * every row — one chart replacing the two cramped donuts, and no truncated
+ * labels.
+ */
+function CategoryBars({ stats, totals }: { stats: ResourceStat[]; totals: Totals }): ReactElement {
+  const [metric, setMetric] = useState<'bytes' | 'files'>('bytes');
+  const rows = stats
+    .slice()
+    .sort((a, b) => (metric === 'bytes' ? b.bytes - a.bytes : b.files - a.files));
+  const totalMetric = metric === 'bytes' ? totals.bytes : totals.files;
+  const max = Math.max(...rows.map((s) => (metric === 'bytes' ? s.bytes : s.files)), 1);
+
+  return (
+    <div className="weq-ra-barwrap">
+      <div className="weq-ra-metric">
+        <button
+          type="button"
+          className={metric === 'bytes' ? 'is-on' : ''}
+          onClick={() => setMetric('bytes')}
+        >
+          大小
+        </button>
+        <button
+          type="button"
+          className={metric === 'files' ? 'is-on' : ''}
+          onClick={() => setMetric('files')}
+        >
+          数量
+        </button>
+      </div>
+      <div className="weq-ra-bars">
+        {rows.map((s) => {
+          const value = metric === 'bytes' ? s.bytes : s.files;
+          const pct = totalMetric > 0 ? (value / totalMetric) * 100 : 0;
+          const width = max > 0 ? (value / max) * 100 : 0;
+          const primary = metric === 'bytes' ? fmtBytes(s.bytes) : `${formatNumber(s.files)} 个`;
+          const secondary = metric === 'bytes' ? `${formatNumber(s.files)} 个` : fmtBytes(s.bytes);
+          return (
+            <div className="weq-ra-bar-row" key={s.key}>
+              <span className="weq-ra-bar-label">
+                <i style={{ background: colorOf(s.key) }} />
+                {labelOf(s.key)}
+              </span>
+              <span className="weq-ra-bar-track">
+                <span
+                  className="weq-ra-bar-fill"
+                  style={{
+                    width: `${Math.max(width, value > 0 ? 2 : 0)}%`,
+                    background: colorOf(s.key),
+                  }}
+                />
+              </span>
+              <span className="weq-ra-bar-val">
+                <b>{primary}</b>
+                <small>
+                  {pct >= 10 ? pct.toFixed(0) : pct.toFixed(1)}% · {secondary}
+                </small>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** Slim 100% stacked bar (by bytes) for the 源文件 / 缩略图 / 其它 split. */
+function ShareBar({
+  segments,
+}: {
+  segments: Array<{ label: string; bytes: number; files: number; color: string }>;
+}): ReactElement {
+  const total = segments.reduce((s, x) => s + Math.max(0, x.bytes), 0);
+  return (
+    <div className="weq-ra-sharewrap">
+      <div className="weq-ra-sharebar">
+        {segments.map((s) =>
+          s.bytes > 0 ? (
+            <span
+              key={s.label}
+              className="weq-ra-shareseg"
+              style={{ width: `${(s.bytes / total) * 100}%`, background: s.color }}
+              title={`${s.label} · ${fmtBytes(s.bytes)} · ${s.files} 个`}
+            />
+          ) : null,
+        )}
+      </div>
+      <div className="weq-ra-sharelegend">
+        {segments.map((s) => {
+          const pct = total > 0 ? (s.bytes / total) * 100 : 0;
+          return (
+            <span className="weq-ra-shareitem" key={s.label}>
+              <i style={{ background: s.color }} />
+              <span className="weq-ra-share-lbl">{s.label}</span>
+              <span className="weq-ra-share-val">
+                {fmtBytes(s.bytes)} · {pct >= 10 ? pct.toFixed(0) : pct.toFixed(1)}%
+              </span>
+            </span>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/views/cache/ResourceCleanupDialog.tsx
+++ b/apps/desktop/src/renderer/src/views/cache/ResourceCleanupDialog.tsx
@@ -1,0 +1,637 @@
+/**
+ * 清理释放 — a full-screen overlay for reclaiming disk space from the account's
+ * nt_data resource trees. Mirrors {@link ResourceAnalyticsDialog}'s look (portal
+ * overlay, accent-themed) but is DESTRUCTIVE.
+ *
+ * Flow: on open it scans every deletable target for its on-disk size, then offers
+ * five presets (完全安全清理 / 清理原图 / 清理缩略 / 清理 File 目录 / 全部清理) plus a
+ * 自定义 panel. Picking a mode moves to a review step listing exactly what will be
+ * deleted + the total; a `caution`-containing mode arms a red button, and 全部清理
+ * additionally requires typing 「确认清理」. Executing calls
+ * `account.resourceCleanup.cleanup`, then invalidates `account.*` so every
+ * resource browser + 整体分析 rescans from disk.
+ *
+ * The 「下载文件」listing is NOT a target here, so no mode can ever remove the
+ * user's own downloaded files.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  X,
+  Loader2,
+  Trash2,
+  ShieldCheck,
+  Image as ImageIcon,
+  Images,
+  Folder,
+  Film,
+  AudioLines,
+  Cloud,
+  Store,
+  Smile,
+  Sticker,
+  ChevronLeft,
+  CheckCircle2,
+  AlertTriangle,
+  Sparkles,
+  Layers,
+} from 'lucide-react';
+import type { CleanupTargetStat, CleanupVariant, CleanupResult } from '@weq/service';
+import { client, trpc } from '../../trpc/client';
+import { fmtBytes } from './FileResourceShared';
+
+/** One deletion instruction (target + how much). */
+interface Instruction {
+  id: string;
+  variant: CleanupVariant;
+}
+
+/** A preset cleanup mode. */
+interface Preset {
+  id: string;
+  label: string;
+  icon: ReactNode;
+  desc: string;
+  /** true → red button + a caution notice (contains 不可再生 content). */
+  danger: boolean;
+  /** true → also requires typing the confirm phrase (全部清理 only). */
+  extreme?: boolean;
+  /** Build the instruction list from the scanned targets. */
+  build: (targets: CleanupTargetStat[]) => Instruction[];
+}
+
+const VARIANT_TARGET_IDS = ['pic', 'video', 'emojiRecv', 'personalEmoji'] as const;
+
+const PRESETS: Preset[] = [
+  {
+    id: 'safe',
+    label: '完全安全清理',
+    icon: <ShieldCheck size={20} />,
+    desc: '清理头像、商城表情、图片墙、QQ空间、关联表情等完全可再生的缓存，QQ 会在需要时自动重新下载。',
+    danger: false,
+    build: (targets) => targets.filter((t) => t.tier === 'safe').map((t) => ({ id: t.id, variant: 'all' })),
+  },
+  {
+    id: 'ori',
+    label: '清理原图',
+    icon: <ImageIcon size={20} />,
+    desc: '删除图片 / 视频 / 表情的原始文件，保留缩略图预览。释放空间最多，但原图过期后可能无法恢复。',
+    danger: true,
+    build: (targets) =>
+      targets
+        .filter((t) => VARIANT_TARGET_IDS.includes(t.id as (typeof VARIANT_TARGET_IDS)[number]) && t.ori.files > 0)
+        .map((t) => ({ id: t.id, variant: 'ori' })),
+  },
+  {
+    id: 'thumb',
+    label: '清理缩略',
+    icon: <Images size={20} />,
+    desc: '删除图片 / 视频 / 表情的缩略图预览，保留原始文件。需要时会重新生成。',
+    danger: false,
+    build: (targets) =>
+      targets
+        .filter((t) => VARIANT_TARGET_IDS.includes(t.id as (typeof VARIANT_TARGET_IDS)[number]) && t.thumb.files > 0)
+        .map((t) => ({ id: t.id, variant: 'thumb' })),
+  },
+  {
+    id: 'file',
+    label: '清理 File 目录',
+    icon: <Folder size={20} />,
+    desc: '清理 nt_data/File 聊天文件缓存。不影响你在「下载文件」里主动下载保存的文件。',
+    danger: true,
+    build: () => [{ id: 'file', variant: 'all' }],
+  },
+  {
+    id: 'all',
+    label: '全部清理',
+    icon: <Trash2 size={20} />,
+    desc: '清理全部本地资源缓存，包括聊天图片、视频、语音等不可再生内容。危险操作，请务必谨慎。',
+    danger: true,
+    extreme: true,
+    build: (targets) => targets.map((t) => ({ id: t.id, variant: 'all' })),
+  },
+];
+
+const CONFIRM_PHRASE = '确认清理';
+
+/** Per-target icon for the 自定义 list + review rows. */
+const TARGET_ICONS: Record<string, ReactNode> = {
+  avatar: <ImageIcon size={15} />,
+  marketface: <Store size={15} />,
+  photoWall: <Images size={15} />,
+  qzone: <Cloud size={15} />,
+  emojiRelated: <Smile size={15} />,
+  pic: <ImageIcon size={15} />,
+  video: <Film size={15} />,
+  emojiRecv: <Sticker size={15} />,
+  personalEmoji: <Sticker size={15} />,
+  ptt: <AudioLines size={15} />,
+  file: <Folder size={15} />,
+};
+
+/** Bytes a single instruction would free, given the scanned target. */
+function instructionBytes(t: CleanupTargetStat, variant: CleanupVariant): number {
+  if (variant === 'ori') return t.ori.bytes;
+  if (variant === 'thumb') return t.thumb.bytes;
+  return t.bytes;
+}
+
+/** Total bytes a set of instructions would free. */
+function estimateBytes(targets: CleanupTargetStat[], instructions: Instruction[]): number {
+  let total = 0;
+  for (const ins of instructions) {
+    const t = targets.find((x) => x.id === ins.id);
+    if (t) total += instructionBytes(t, ins.variant);
+  }
+  return total;
+}
+
+const VARIANT_LABEL: Record<CleanupVariant, string> = { all: '全部', ori: '仅原图', thumb: '仅缩略' };
+
+export function ResourceCleanupDialog({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}): ReactElement | null {
+  const utils = trpc.useUtils();
+  const [targets, setTargets] = useState<CleanupTargetStat[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // pick → confirm → running → done
+  const [stage, setStage] = useState<'pick' | 'confirm' | 'running' | 'done'>('pick');
+  const [chosen, setChosen] = useState<{ preset: Preset; instructions: Instruction[] } | null>(null);
+  const [customMode, setCustomMode] = useState(false);
+  const [customSel, setCustomSel] = useState<Record<string, CleanupVariant>>({});
+  const [phrase, setPhrase] = useState('');
+  const [result, setResult] = useState<CleanupResult | null>(null);
+
+  const runRef = useRef(0);
+
+  const resetState = useCallback((): void => {
+    setStage('pick');
+    setChosen(null);
+    setCustomMode(false);
+    setCustomSel({});
+    setPhrase('');
+    setResult(null);
+  }, []);
+
+  const scan = useCallback(async (): Promise<void> => {
+    const run = ++runRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await client.account.resourceCleanup.listTargets.query();
+      if (run !== runRef.current) return;
+      setTargets(list);
+    } catch (e) {
+      if (run === runRef.current) setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      if (run === runRef.current) setLoading(false);
+    }
+  }, []);
+
+  // Fresh scan + reset every time the dialog opens.
+  useEffect(() => {
+    if (open) {
+      resetState();
+      void scan();
+    } else {
+      runRef.current += 1;
+    }
+  }, [open, scan, resetState]);
+
+  // ESC to close (except mid-run — don't lose a delete in flight).
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape' && stage !== 'running') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose, stage]);
+
+  const totalBytes = useMemo(() => targets.reduce((s, t) => s + t.bytes, 0), [targets]);
+
+  // Custom selection → instruction list.
+  const customInstructions = useMemo<Instruction[]>(
+    () => Object.entries(customSel).map(([id, variant]) => ({ id, variant })),
+    [customSel],
+  );
+
+  if (!open || typeof document === 'undefined') return null;
+
+  const pickPreset = (preset: Preset): void => {
+    const instructions = preset.build(targets).filter((ins) => {
+      const t = targets.find((x) => x.id === ins.id);
+      return t && t.present && instructionBytes(t, ins.variant) >= 0 && t.files > 0;
+    });
+    setChosen({ preset, instructions });
+    setPhrase('');
+    setStage('confirm');
+  };
+
+  const pickCustom = (): void => {
+    const anyCaution = customInstructions.some((ins) => targets.find((t) => t.id === ins.id)?.tier === 'caution');
+    const preset: Preset = {
+      id: 'custom',
+      label: '自定义清理',
+      icon: <Sparkles size={20} />,
+      desc: '仅清理你勾选的资源。',
+      danger: anyCaution,
+      build: () => customInstructions,
+    };
+    setChosen({ preset, instructions: customInstructions });
+    setPhrase('');
+    setStage('confirm');
+  };
+
+  const runCleanup = async (): Promise<void> => {
+    if (!chosen) return;
+    setStage('running');
+    try {
+      const res = await client.account.resourceCleanup.cleanup.mutate({ instructions: chosen.instructions });
+      setResult(res);
+      setStage('done');
+      // Every browser + 整体分析 reads these trees — force a rescan on next open.
+      void utils.account.invalidate();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setStage('confirm');
+    }
+  };
+
+  const toggleCustom = (t: CleanupTargetStat): void => {
+    setCustomSel((prev) => {
+      const next = { ...prev };
+      if (next[t.id]) delete next[t.id];
+      else next[t.id] = 'all';
+      return next;
+    });
+  };
+
+  const setCustomVariant = (id: string, variant: CleanupVariant): void => {
+    setCustomSel((prev) => ({ ...prev, [id]: variant }));
+  };
+
+  return createPortal(
+    <div
+      className="weq-ra-layer weq-anim-fade"
+      onMouseDown={() => {
+        if (stage !== 'running') onClose();
+      }}
+    >
+      <div className="weq-ra-dialog weq-clean-dialog weq-anim-pop" onMouseDown={(e) => e.stopPropagation()}>
+        <header className="weq-ra-head">
+          <div className="weq-ra-head-title">
+            <Trash2 size={18} />
+            <div>
+              <strong>清理释放本地资源</strong>
+              <small>删除 QQ 本地缓存以释放磁盘空间，可再生资源会自动重新下载</small>
+            </div>
+          </div>
+          <div className="weq-ra-head-actions">
+            {loading ? <Loader2 size={14} className="weq-spin" /> : null}
+            <span className="weq-clean-total">共 {fmtBytes(totalBytes)}</span>
+            <button
+              type="button"
+              className="weq-ra-close"
+              onClick={onClose}
+              disabled={stage === 'running'}
+              aria-label="关闭"
+            >
+              <X size={18} />
+            </button>
+          </div>
+        </header>
+
+        {error ? (
+          <div className="weq-ra-error">
+            <AlertTriangle size={14} /> {error}
+          </div>
+        ) : null}
+
+        <div className="weq-ra-body weq-clean-body">
+          {stage === 'pick' ? (
+            <PickStage
+              targets={targets}
+              loading={loading}
+              customMode={customMode}
+              customSel={customSel}
+              customInstructions={customInstructions}
+              onEnterCustom={() => setCustomMode(true)}
+              onLeaveCustom={() => {
+                setCustomMode(false);
+                setCustomSel({});
+              }}
+              onToggleCustom={toggleCustom}
+              onSetVariant={setCustomVariant}
+              onPickPreset={pickPreset}
+              onConfirmCustom={pickCustom}
+            />
+          ) : null}
+
+          {stage === 'confirm' && chosen ? (
+            <ConfirmStage
+              targets={targets}
+              chosen={chosen}
+              phrase={phrase}
+              onPhrase={setPhrase}
+              onBack={() => {
+                setStage('pick');
+                setError(null);
+              }}
+              onRun={() => void runCleanup()}
+            />
+          ) : null}
+
+          {stage === 'running' ? (
+            <div className="weq-clean-running">
+              <Loader2 size={26} className="weq-spin" />
+              <strong>正在清理…</strong>
+              <span>正在删除文件并释放空间，请稍候</span>
+            </div>
+          ) : null}
+
+          {stage === 'done' && result ? (
+            <DoneStage
+              result={result}
+              onClose={onClose}
+              onAgain={() => {
+                resetState();
+                void scan();
+              }}
+            />
+          ) : null}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ── pick stage ───────────────────────────────────────────────────────────────
+
+function PickStage({
+  targets,
+  loading,
+  customMode,
+  customSel,
+  customInstructions,
+  onEnterCustom,
+  onLeaveCustom,
+  onToggleCustom,
+  onSetVariant,
+  onPickPreset,
+  onConfirmCustom,
+}: {
+  targets: CleanupTargetStat[];
+  loading: boolean;
+  customMode: boolean;
+  customSel: Record<string, CleanupVariant>;
+  customInstructions: Instruction[];
+  onEnterCustom: () => void;
+  onLeaveCustom: () => void;
+  onToggleCustom: (t: CleanupTargetStat) => void;
+  onSetVariant: (id: string, v: CleanupVariant) => void;
+  onPickPreset: (p: Preset) => void;
+  onConfirmCustom: () => void;
+}): ReactElement {
+  if (customMode) {
+    const selBytes = estimateBytes(targets, customInstructions);
+    const anySel = customInstructions.length > 0;
+    return (
+      <div className="weq-clean-custom">
+        <button type="button" className="weq-clean-back" onClick={onLeaveCustom}>
+          <ChevronLeft size={15} /> 返回清理模式
+        </button>
+        <div className="weq-clean-target-list">
+          {targets.map((t) => {
+            const sel = customSel[t.id];
+            const on = sel !== undefined;
+            const disabled = !t.present || t.files === 0;
+            return (
+              <div key={t.id} className={`weq-clean-target${on ? ' is-on' : ''}${disabled ? ' is-disabled' : ''}`}>
+                <button
+                  type="button"
+                  className="weq-clean-target-main"
+                  onClick={() => !disabled && onToggleCustom(t)}
+                  disabled={disabled}
+                >
+                  <span className={`weq-clean-check${on ? ' is-on' : ''}`}>{on ? <CheckCircle2 size={16} /> : null}</span>
+                  <span className="weq-clean-target-icon">{TARGET_ICONS[t.id]}</span>
+                  <span className="weq-clean-target-text">
+                    <strong>
+                      {t.label}
+                      <em className={`weq-clean-tier is-${t.tier}`}>{t.tier === 'safe' ? '可再生' : '谨慎'}</em>
+                    </strong>
+                    <small>{t.desc}</small>
+                  </span>
+                  <span className="weq-clean-target-size">{disabled ? '空' : fmtBytes(t.bytes)}</span>
+                </button>
+                {on && t.hasVariants ? (
+                  <div className="weq-clean-variants">
+                    {(['all', 'ori', 'thumb'] as CleanupVariant[]).map((v) => (
+                      <button
+                        key={v}
+                        type="button"
+                        className={sel === v ? 'is-on' : ''}
+                        onClick={() => onSetVariant(t.id, v)}
+                      >
+                        {VARIANT_LABEL[v]}
+                        <i>
+                          {v === 'all' ? fmtBytes(t.bytes) : v === 'ori' ? fmtBytes(t.ori.bytes) : fmtBytes(t.thumb.bytes)}
+                        </i>
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+        <div className="weq-clean-custom-foot">
+          <span>
+            已选 <strong>{customInstructions.length}</strong> 项 · 预计释放 <strong>{fmtBytes(selBytes)}</strong>
+          </span>
+          <button type="button" className="weq-clean-go is-danger" disabled={!anySel} onClick={onConfirmCustom}>
+            <Trash2 size={15} /> 清理所选
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="weq-clean-modes">
+      {PRESETS.map((p) => {
+        const instructions = p.build(targets);
+        const bytes = estimateBytes(targets, instructions);
+        const empty = !loading && bytes === 0;
+        return (
+          <button
+            key={p.id}
+            type="button"
+            className={`weq-clean-mode${p.danger ? ' is-danger' : ''}${p.extreme ? ' is-extreme' : ''}`}
+            onClick={() => onPickPreset(p)}
+            disabled={empty}
+          >
+            <span className="weq-clean-mode-icon">{p.icon}</span>
+            <span className="weq-clean-mode-body">
+              <strong>{p.label}</strong>
+              <small>{p.desc}</small>
+            </span>
+            <span className="weq-clean-mode-size">
+              {loading ? <Loader2 size={13} className="weq-spin" /> : empty ? '无可清理' : `约 ${fmtBytes(bytes)}`}
+            </span>
+          </button>
+        );
+      })}
+      <button type="button" className="weq-clean-mode is-custom" onClick={onEnterCustom}>
+        <span className="weq-clean-mode-icon">
+          <Sparkles size={20} />
+        </span>
+        <span className="weq-clean-mode-body">
+          <strong>自定义清理</strong>
+          <small>自由勾选要清理的资源，并选择清理原图或缩略。</small>
+        </span>
+        <span className="weq-clean-mode-size">
+          <ChevronLeft size={15} style={{ transform: 'rotate(180deg)' }} />
+        </span>
+      </button>
+    </div>
+  );
+}
+
+// ── confirm stage ────────────────────────────────────────────────────────────
+
+function ConfirmStage({
+  targets,
+  chosen,
+  phrase,
+  onPhrase,
+  onBack,
+  onRun,
+}: {
+  targets: CleanupTargetStat[];
+  chosen: { preset: Preset; instructions: Instruction[] };
+  phrase: string;
+  onPhrase: (v: string) => void;
+  onBack: () => void;
+  onRun: () => void;
+}): ReactElement {
+  const { preset, instructions } = chosen;
+  const bytes = estimateBytes(targets, instructions);
+  const rows = instructions
+    .map((ins) => {
+      const t = targets.find((x) => x.id === ins.id);
+      return t ? { t, variant: ins.variant, bytes: instructionBytes(t, ins.variant) } : null;
+    })
+    .filter((r): r is { t: CleanupTargetStat; variant: CleanupVariant; bytes: number } => r !== null)
+    .sort((a, b) => b.bytes - a.bytes);
+
+  const phraseOk = !preset.extreme || phrase.trim() === CONFIRM_PHRASE;
+  const nothing = rows.length === 0;
+
+  return (
+    <div className="weq-clean-confirm">
+      <button type="button" className="weq-clean-back" onClick={onBack}>
+        <ChevronLeft size={15} /> 重新选择
+      </button>
+
+      <div className={`weq-clean-summary${preset.danger ? ' is-danger' : ''}`}>
+        <span className="weq-clean-summary-icon">{preset.danger ? <AlertTriangle size={20} /> : <ShieldCheck size={20} />}</span>
+        <div>
+          <strong>{preset.label}</strong>
+          <p>{preset.desc}</p>
+        </div>
+        <span className="weq-clean-summary-size">
+          <b>{fmtBytes(bytes)}</b>
+          <small>预计释放</small>
+        </span>
+      </div>
+
+      {nothing ? (
+        <div className="weq-clean-empty">没有可清理的内容。</div>
+      ) : (
+        <div className="weq-clean-review">
+          {rows.map(({ t, variant, bytes: b }) => (
+            <div className="weq-clean-review-row" key={`${t.id}:${variant}`}>
+              <span className="weq-clean-target-icon">{TARGET_ICONS[t.id]}</span>
+              <span className="weq-clean-review-label">{t.label}</span>
+              {t.hasVariants ? <em className="weq-clean-review-variant">{VARIANT_LABEL[variant]}</em> : null}
+              <span className="weq-clean-review-size">{fmtBytes(b)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {preset.extreme ? (
+        <label className="weq-clean-phrase">
+          <span>
+            这是危险操作，将删除聊天图片 / 视频 / 语音等不可再生内容。请输入 <b>{CONFIRM_PHRASE}</b> 以确认：
+          </span>
+          <input
+            type="text"
+            value={phrase}
+            onChange={(e) => onPhrase(e.target.value)}
+            placeholder={CONFIRM_PHRASE}
+            autoFocus
+          />
+        </label>
+      ) : null}
+
+      <div className="weq-clean-confirm-foot">
+        <button type="button" className="weq-clean-cancel" onClick={onBack}>
+          取消
+        </button>
+        <button
+          type="button"
+          className={`weq-clean-go${preset.danger ? ' is-danger' : ''}`}
+          disabled={nothing || !phraseOk}
+          onClick={onRun}
+        >
+          <Trash2 size={15} /> 确认清理 {fmtBytes(bytes)}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── done stage ───────────────────────────────────────────────────────────────
+
+function DoneStage({
+  result,
+  onClose,
+  onAgain,
+}: {
+  result: CleanupResult;
+  onClose: () => void;
+  onAgain: () => void;
+}): ReactElement {
+  const failed = result.perTarget.reduce((s, t) => s + t.failed, 0);
+  return (
+    <div className="weq-clean-done">
+      <span className="weq-clean-done-icon">
+        <CheckCircle2 size={40} strokeWidth={1.5} />
+      </span>
+      <strong className="weq-clean-done-title">已释放 {fmtBytes(result.freedBytes)}</strong>
+      <p className="weq-clean-done-desc">
+        清理完成，共处理 {result.perTarget.length} 项资源。
+        {failed > 0 ? `有 ${failed} 个文件因被占用未能删除（可关闭 QQ 后重试）。` : ''}
+      </p>
+      <div className="weq-clean-done-actions">
+        <button type="button" className="weq-clean-cancel" onClick={onAgain}>
+          <Layers size={15} /> 继续清理
+        </button>
+        <button type="button" className="weq-clean-go" onClick={onClose}>
+          完成
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/views/export/ExportLightbox.tsx
+++ b/apps/desktop/src/renderer/src/views/export/ExportLightbox.tsx
@@ -22,7 +22,7 @@ import {
   type Schedule,
 } from './types';
 
-export type LightboxVariant = 'full' | 'chatlab' | 'qzone' | 'scheduled' | 'album';
+export type LightboxVariant = 'full' | 'chatlab' | 'qzone' | 'scheduled' | 'album' | 'contacts';
 
 export interface LightboxResult {
   options: ExportOptions;
@@ -61,6 +61,7 @@ export function ExportLightbox({
   const isAlbum = variant === 'album';
   const isQzone = variant === 'qzone';
   const isScheduled = variant === 'scheduled';
+  const isContacts = variant === 'contacts';
 
   function patch(next: Partial<ExportOptions>): void {
     setOpts((o) => ({ ...o, ...next }));
@@ -155,14 +156,34 @@ export function ExportLightbox({
             </Card>
           ) : null}
 
-          {/* 时间范围 */}
-          <Card title="时间范围">
-            <TimeRangePicker
-              value={opts.range}
-              onChange={(range) => patch({ range })}
-              mode={isScheduled ? 'scheduled' : 'single'}
-            />
-          </Card>
+          {/* 联系人导出说明 + 头像 */}
+          {isContacts ? (
+            <Card title="导出联系人">
+              <div className="weq-exp-placeholder">
+                <span>导出好友列表 / 群成员列表（QQ号、昵称、备注、分组、角色等）</span>
+                <small>
+                  数据来自本地资料库，无需在线 QQ。开启下方「导出头像」后，头像存入同目录
+                  avatars/ 子文件夹（导出结果保存为文件夹）。
+                </small>
+              </div>
+              <Row
+                label="导出头像"
+                desc="联系人头像存入 avatars/ 子目录（缓存优先，缺失走 CDN 补齐）"
+                control={<Toggle checked={opts.exportAvatar} onChange={(v) => patch({ exportAvatar: v })} />}
+              />
+            </Card>
+          ) : null}
+
+          {/* 时间范围（联系人无时间维度，不显示） */}
+          {!isContacts ? (
+            <Card title="时间范围">
+              <TimeRangePicker
+                value={opts.range}
+                onChange={(range) => patch({ range })}
+                mode={isScheduled ? 'scheduled' : 'single'}
+              />
+            </Card>
+          ) : null}
 
           {/* 好友空间：只需「是否下载配图」一个开关 */}
           {isQzone ? (
@@ -176,7 +197,7 @@ export function ExportLightbox({
           ) : null}
 
           {/* 媒体 / 内容选项（完整消息 / ChatLab / 定时；HTML 也支持） */}
-          {!isAlbum && !isQzone ? (
+          {!isAlbum && !isQzone && !isContacts ? (
             <Card title="媒体与内容">
               <Row
                 label="导出媒体文件"

--- a/apps/desktop/src/renderer/src/views/export/types.ts
+++ b/apps/desktop/src/renderer/src/views/export/types.ts
@@ -8,11 +8,11 @@
  */
 
 /** Left-rail modes. */
-export type ExportMode = 'full' | 'decrypt' | 'chatlab' | 'qzone' | 'scheduled' | 'album';
+export type ExportMode = 'full' | 'decrypt' | 'chatlab' | 'qzone' | 'contacts' | 'scheduled' | 'album';
 
-/** Every output format the 完整消息 / 定时 flows can request. HTML is now one of
- *  the 完整消息 format chips (merged from its old standalone mode). */
-export type ExportFormat = 'json' | 'jsonl' | 'xlsx' | 'csv' | 'txt' | 'html';
+/** Every output format the 完整消息 / 定时 flows can request. HTML is one of the
+ *  完整消息 chips; `vcard` is contacts-only (导出联系人). */
+export type ExportFormat = 'json' | 'jsonl' | 'xlsx' | 'csv' | 'txt' | 'html' | 'vcard';
 
 /** Formats the backend (`account.startExport`) can produce. */
 export const BACKEND_FORMATS = ['json', 'jsonl', 'txt', 'csv', 'xlsx'] as const;
@@ -41,6 +41,23 @@ export const CHATLAB_FORMATS: Array<{ value: ExportFormat; label: string }> = [
 
 /** 好友 QQ 空间导出仅 JSON / TXT。 */
 export const QZONE_FORMATS: Array<{ value: ExportFormat; label: string }> = [
+  { value: 'json', label: 'JSON' },
+  { value: 'txt', label: 'TXT' },
+];
+
+/** 导出好友：表格类 + vCard 电子名片。 */
+export const FRIEND_FORMATS: Array<{ value: ExportFormat; label: string }> = [
+  { value: 'csv', label: 'CSV' },
+  { value: 'xlsx', label: 'XLSX' },
+  { value: 'json', label: 'JSON' },
+  { value: 'txt', label: 'TXT' },
+  { value: 'vcard', label: 'vCard' },
+];
+
+/** 导出群成员：表格类（无 vCard）。 */
+export const MEMBER_FORMATS: Array<{ value: ExportFormat; label: string }> = [
+  { value: 'csv', label: 'CSV' },
+  { value: 'xlsx', label: 'XLSX' },
   { value: 'json', label: 'JSON' },
   { value: 'txt', label: 'TXT' },
 ];

--- a/apps/protolab/src/renderer/src/lib/elementValidator.ts
+++ b/apps/protolab/src/renderer/src/lib/elementValidator.ts
@@ -129,7 +129,7 @@ function getTagForField(fieldName: string): number {
     summary: 45815,
     cdnHost: 45816,
     filePath: 45403,
-    pttType: 45906,
+    pttDuration: 45906,
     voiceChanged: 45911,
     waveform: 45925,
     faceId: 47601,

--- a/packages/codec/src/element/compose.ts
+++ b/packages/codec/src/element/compose.ts
@@ -174,6 +174,22 @@ export interface ComposeParseOk {
 }
 export type ComposeParseResult = ComposeParseOk | ComposeParseError;
 
+/**
+ * Coerce a quoted (reply.origElements) element. A lifted `pic` carries CDN
+ * fields whose numeric/bigint leaves arrive as strings over IPC, so run it
+ * through the lenient pic schema to restore their types before it is re-encoded
+ * into the stored quote. Text/@/face need no coercion, and wire-form items
+ * (elementType, no `kind`) are left untouched. Never throws — an unparseable
+ * item is returned verbatim so the insert still succeeds.
+ */
+function coerceOrigElement(raw: unknown): unknown {
+  if ((raw as { kind?: string })?.kind === 'pic') {
+    const res = COERCED_SCHEMAS.pic.safeParse(raw);
+    if (res.success) return res.data;
+  }
+  return raw;
+}
+
 /** Validate + coerce one authored element. */
 function parseComposeElement(raw: unknown): { ok: true; element: Element } | ComposeParseError {
   const kind = (raw as { kind?: string })?.kind;
@@ -184,7 +200,11 @@ function parseComposeElement(raw: unknown): { ok: true; element: Element } | Com
   if (!res.success) {
     return { ok: false, error: `${kind} 校验失败: ${res.error.issues.map((i) => `${i.path.join('.')} ${i.message}`).join('; ')}` };
   }
-  return { ok: true, element: res.data as Element };
+  const element = res.data as Element & { origElements?: unknown };
+  if (kind === 'reply' && Array.isArray(element.origElements)) {
+    element.origElements = element.origElements.map(coerceOrigElement);
+  }
+  return { ok: true, element: element as Element };
 }
 
 /**

--- a/packages/codec/src/element/registry.ts
+++ b/packages/codec/src/element/registry.ts
@@ -110,6 +110,19 @@ export function decodePreviewElement(
 export function encodeElement(el: Element): ProtoEncodeStructType<typeof ElementWire> {
   if (el.kind === 'unknown') return el.raw;
   const { kind, ...rest } = el;
+  // A `reply` element nests the quoted message's `origElements`. When authored
+  // in kind-tagged form (compose / insert), encode each to wire so the stored
+  // bytes are real nested Elements — decodeElement keys off `elementType`, which
+  // a kind-tagged object lacks. Items already in wire form (no `kind`) pass
+  // through untouched, so decoded-then-re-encoded replies stay stable.
+  if (kind === 'reply') {
+    const nested = (rest as { origElements?: unknown }).origElements;
+    if (Array.isArray(nested)) {
+      (rest as { origElements?: unknown[] }).origElements = nested.map((o) =>
+        o && typeof o === 'object' && 'kind' in o ? encodeElement(o as Element) : o,
+      );
+    }
+  }
   return {
     ...rest,
     elementType: KIND_TO_TYPE[kind as KnownKind],

--- a/packages/codec/src/element/spec.ts
+++ b/packages/codec/src/element/spec.ts
@@ -13,7 +13,6 @@ import {
   ElementType,
   PicSubType,
   PicType,
-  PttType,
   GrayTipSubType,
   CallSubType,
   CallType,
@@ -174,8 +173,13 @@ export const PttElementSchema = BaseElementFieldsSchema.extend({
   uploadTimestamp: z.number(),
   fileTTL: z.number(),
   summary: z.array(z.string()),
-  pttType: z.nativeEnum(PttType),
+  /** Clip duration in seconds (wire tag 45906). Authoritative for both the
+   * 时长 label and bubble width — waveform length is not. */
+  pttDuration: z.number(),
   voiceChanged: z.boolean(),
+  /** AI 声聊 flag (wire tag 45915): true only on AI-voice-chat clips, absent
+   * otherwise. Reliable classifier; their waveform is a synthetic placeholder. */
+  isAiVoice: z.boolean().optional(),
   waveform: z.instanceof(Uint8Array),
   transferState: z.number().optional(),
   picTransferState: z.number().optional(),

--- a/packages/codec/src/element/spec.ts
+++ b/packages/codec/src/element/spec.ts
@@ -368,6 +368,7 @@ export const WalletElementSchema = BaseElementFieldsSchema.extend({
   walletFlag48417: z.instanceof(Uint8Array).optional(),
   walletFlag48418: z.string().optional(),
   walletFlag48419: z.number().optional(),
+  walletDesignatedUin: z.number().optional(),
   walletExt: z.any().optional(),
   walletFlag48437: z.number().optional(),
   walletFlag48438: z.number().optional(),

--- a/packages/codec/src/element/types.ts
+++ b/packages/codec/src/element/types.ts
@@ -111,6 +111,28 @@ export enum CallType {
   REMOTE_ASSIST = 5,
 }
 
+/**
+ * 红包 / 转账类型 — value of WALLET wire tag 48412 (`walletRedbagType`).
+ *
+ * TRANSFER/NORMAL/PASSWORD/VOICE 来自早期 RE；LUCKY(3) 与 DESIGNATED(8) 为实测
+ * 确认（对比同群拼手气红包与专属红包的 msgBody）。DESIGNATED 红包会额外带 wire
+ * tag 48420 (`walletDesignatedUin`) 指定唯一可领取的群友 uin。
+ */
+export enum RedbagType {
+  /** 转账。 */
+  TRANSFER = 1,
+  /** 普通红包（等额）。 */
+  NORMAL = 2,
+  /** 拼手气红包。 */
+  LUCKY = 3,
+  /** 口令红包。 */
+  PASSWORD = 6,
+  /** 专属红包（指定领取人，见 walletDesignatedUin/48420）。 */
+  DESIGNATED = 8,
+  /** 语音红包。 */
+  VOICE = 15,
+}
+
 export enum FaceSubType {
   QQ_BUILTIN_OLD = 1,
   QQ_BUILTIN_NEW = 2,

--- a/packages/codec/src/element/types.ts
+++ b/packages/codec/src/element/types.ts
@@ -77,11 +77,6 @@ export enum PicType {
   ORIGINAL = 1001,
 }
 
-export enum PttType {
-  INTERCOM = 1,
-  RECORDING = 2,
-}
-
 export enum GrayTipSubType {
   REVOKE = 1,
   GROUP_TIP = 4,

--- a/packages/codec/src/proto/msg/48902.ts
+++ b/packages/codec/src/proto/msg/48902.ts
@@ -1,9 +1,65 @@
 /**
  * 48902 — msg_unread_info_table unread info blob.
- * Contains the last read message sequence number for a conversation.
+ *
+ * Contains the last-read message sequence number for a conversation, plus an
+ * optional "notify highlight" extension (50005 → 50060) that QQ NT populates
+ * when the conversation has unread messages of special interest:
+ * 特别关心 / @我 / @全体 / 回复我 / 新文件 …
+ *
+ * Only the 特别关心 (special-care) shape is modelled so far — it's the one
+ * we've decoded end-to-end. Its nested layout (verified against a real blob):
+ *
+ *   50005 {                       // conversation extension
+ *     50001 peerUid, 50002 chatType
+ *     50060 {                     // notify-highlight aggregate (absent when none)
+ *       50000 kind                // observed 1006 for 特别关心
+ *       50040 {                   // one entry per highlighted message
+ *         50020 msgSeq            // seq of the highlighted message
+ *         50022 senderUid         // who sent it
+ *         50023 sendTime          // unix seconds
+ *         50024 text              // preview text (often empty)
+ *       }
+ *     }
+ *   }
+ *
+ * Other categories (@我 etc.) will slot in here once we capture their blobs —
+ * they are expected to appear either as sibling nested groups or as different
+ * `50000` kind codes, so `highlight` is modelled as `repeat`.
  */
 
 import { ProtoField, ScalarType } from '../../core';
+
+/** 50040 — one highlighted message inside a notify-highlight group. */
+const NotifyHighlightItem = {
+  /** 50020 — seq of the highlighted message. */
+  msgSeq: ProtoField(50020, ScalarType.UINT32, { optional: true }),
+  /** 50022 — sender uid. */
+  senderUid: ProtoField(50022, ScalarType.STRING, { optional: true }),
+  /** 50023 — send time (unix seconds). */
+  sendTime: ProtoField(50023, ScalarType.UINT32, { optional: true }),
+  /** 50024 — preview text (frequently empty). */
+  text: ProtoField(50024, ScalarType.STRING, { optional: true }),
+};
+
+/** 50060 — notify-highlight aggregate; present only when the conversation has
+ *  a highlighted unread (e.g. 特别关心). */
+const NotifyHighlight = {
+  /** 50000 — highlight kind. Observed 1006 for 特别关心. */
+  kind: ProtoField(50000, ScalarType.UINT32, { optional: true }),
+  /** 50040 — highlighted messages (one per message). */
+  items: ProtoField(50040, () => NotifyHighlightItem, { optional: true, repeat: true }),
+};
+
+/** 50005 — conversation extension carrying the notify-highlight aggregate. */
+const UnreadExt = {
+  /** 50001 — peer uid (repeat of 40021). */
+  peerUid: ProtoField(50001, ScalarType.STRING, { optional: true }),
+  /** 50002 — chat type (repeat of 40010). */
+  chatType: ProtoField(50002, ScalarType.UINT32, { optional: true }),
+  /** 50060 — notify-highlight aggregate. Modelled repeat in case categories
+   *  (特别关心 / @我 …) surface as sibling groups. */
+  highlight: ProtoField(50060, () => NotifyHighlight, { optional: true, repeat: true }),
+};
 
 const UnreadInfoInner = {
   /** 聊天类型 */
@@ -12,6 +68,8 @@ const UnreadInfoInner = {
   peerUid: ProtoField(40021, ScalarType.STRING, { optional: true }),
   /** 最新读到的消息序号 */
   msgSeq: ProtoField(41002, ScalarType.UINT32, { optional: true }),
+  /** 会话扩展（特别关心等提醒高亮）。 */
+  ext: ProtoField(50005, () => UnreadExt, { optional: true }),
 };
 
 export const UnreadInfo = {

--- a/packages/codec/src/proto/msg/48902.ts
+++ b/packages/codec/src/proto/msg/48902.ts
@@ -12,7 +12,7 @@
  *   50005 {                       // conversation extension
  *     50001 peerUid, 50002 chatType
  *     50060 {                     // notify-highlight aggregate (absent when none)
- *       50000 kind                // observed 1006 for 特别关心
+ *       50000 kind                // 1000 = @我, 1006 = 特别关心
  *       50040 {                   // one entry per highlighted message
  *         50020 msgSeq            // seq of the highlighted message
  *         50022 senderUid         // who sent it
@@ -22,9 +22,9 @@
  *     }
  *   }
  *
- * Other categories (@我 etc.) will slot in here once we capture their blobs —
- * they are expected to appear either as sibling nested groups or as different
- * `50000` kind codes, so `highlight` is modelled as `repeat`.
+ * One 50060 group appears per active category; the kind code (50000)
+ * distinguishes them. Remaining categories (@全体 / 回复我 / 新文件) will slot
+ * in as their codes are captured, so `highlight` is modelled as `repeat`.
  */
 
 import { ProtoField, ScalarType } from '../../core';
@@ -44,7 +44,7 @@ const NotifyHighlightItem = {
 /** 50060 — notify-highlight aggregate; present only when the conversation has
  *  a highlighted unread (e.g. 特别关心). */
 const NotifyHighlight = {
-  /** 50000 — highlight kind. Observed 1006 for 特别关心. */
+  /** 50000 — highlight kind. 1000 = @我, 1006 = 特别关心. */
   kind: ProtoField(50000, ScalarType.UINT32, { optional: true }),
   /** 50040 — highlighted messages (one per message). */
   items: ProtoField(50040, () => NotifyHighlightItem, { optional: true, repeat: true }),

--- a/packages/codec/src/proto/msg/element.ts
+++ b/packages/codec/src/proto/msg/element.ts
@@ -89,8 +89,9 @@ export const ReplyElementWire = {
   summary: ProtoField(45815, ScalarType.STRING, { repeat: true }),
   cdnHost: ProtoField(45816, ScalarType.STRING, { optional: true }),
   transferState: ProtoField(45550, ScalarType.UINT32, { optional: true }),
-  pttType: ProtoField(45906, ScalarType.UINT32, { optional: true }),
+  pttDuration: ProtoField(45906, ScalarType.UINT32, { optional: true }),
   voiceChanged: ProtoField(45911, ScalarType.BOOL, { optional: true }),
+  isAiVoice: ProtoField(45915, ScalarType.BOOL, { optional: true }),
   waveform: ProtoField(45925, ScalarType.BYTES, { optional: true }),
   faceId: ProtoField(47601, ScalarType.UINT32, { optional: true }),
   faceText: ProtoField(47602, ScalarType.STRING, { optional: true }),
@@ -412,8 +413,12 @@ export const ElementWire = {
   /** Transfer state (optional). */
   transferState: ProtoField(45550, ScalarType.UINT32, { optional: true }),
 
-  /** Voice type: 1=intercom, 2=recording. Required for PTT elements. */
-  pttType: ProtoField(45906, ScalarType.UINT32, { optional: true }),
+  /** Voice clip duration in seconds. Drives both the 时长 label and the bubble
+   * width; the waveform (45925) is decorative and NOT a reliable duration source
+   * (AI 声聊 clips carry a fixed 30-byte synthetic strip regardless of length).
+   * Named `pttDuration` to avoid colliding with the CALL `duration` (48152) that
+   * shares this flat wire struct — a duplicate key would silently drop tag 45906. */
+  pttDuration: ProtoField(45906, ScalarType.UINT32, { optional: true }),
 
   /** PTT protocol flag. */
   pttFlag45907: ProtoField(45907, ScalarType.UINT32, { optional: true }),
@@ -422,6 +427,12 @@ export const ElementWire = {
 
   /** Whether voice is changed/transformed. Required for PTT elements. */
   voiceChanged: ProtoField(45911, ScalarType.BOOL, { optional: true }),
+
+  /** AI 声聊 marker. Present (=true) ONLY on AI-voice-chat clips; absent on
+   * normal mic recordings, 对讲 (intercom), and other-client voices. This is
+   * the reliable classifier — QQ doesn't otherwise flag these, and their
+   * waveform (45925) is a fixed synthetic 30-byte strip. */
+  isAiVoice: ProtoField(45915, ScalarType.BOOL, { optional: true }),
 
   pttFlag45922: ProtoField(45922, ScalarType.UINT32, { optional: true }),
 

--- a/packages/codec/src/proto/msg/element.ts
+++ b/packages/codec/src/proto/msg/element.ts
@@ -797,12 +797,21 @@ export const ElementWire = {
   walletFlag48410: ProtoField(48410, ScalarType.STRING, { optional: true }),
   walletFlag48411: ProtoField(48411, ScalarType.UINT32, { optional: true }),
 
-  /** Redbag type: 1=transfer, 2=normal, 6=password, 15=voice (elementType=9). */
+  /**
+   * Redbag type (elementType=9). See `RedbagType` in `element/types.ts`.
+   * 1=transfer, 2=normal, 3=lucky (拼手气), 6=password, 8=designated (专属), 15=voice.
+   */
   walletRedbagType: ProtoField(48412, ScalarType.UINT32, { optional: true }),
 
   walletFlag48417: ProtoField(48417, ScalarType.BYTES, { optional: true }),
   walletFlag48418: ProtoField(48418, ScalarType.STRING, { optional: true }),
   walletFlag48419: ProtoField(48419, ScalarType.UINT32, { optional: true }),
+
+  /**
+   * Designated recipient uin (elementType=9). Present only on 专属红包
+   * (walletRedbagType=8); the sole group member allowed to claim the packet.
+   */
+  walletDesignatedUin: ProtoField(48420, ScalarType.UINT32, { optional: true }),
 
   /** Extension field (elementType=9). */
   walletExt: ProtoField(48421, () => WalletExtWire, { optional: true }),

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,6 +13,8 @@
     "test:recent-contact": "tsx test/recent_contact.ts",
     "test:recent-contact-all": "tsx test/recent_contact_all.ts",
     "test:recent-contact-dump": "tsx test/recent_contact_dump.ts",
+    "test:verify-avatar-hash": "tsx test/verify_avatar_hash.ts",
+    "test:verify-avatar-probe": "tsx test/verify_avatar_probe.ts",
     "test:inspect-game-center": "tsx test/inspect_game_center.ts",
     "test:insert-weq-assistant": "tsx test/insert_weq_assistant.ts",
     "test:delete-weq-assistant": "tsx test/delete_weq_assistant.ts",

--- a/packages/db/src/contact/recent_contact.ts
+++ b/packages/db/src/contact/recent_contact.ts
@@ -14,6 +14,8 @@
  *   40095  senderRemark        (TEXT)
  *   41110  targetAvatar        (TEXT)
  *   41135  targetRemark        (TEXT, conversation remark)
+ *   41220  notifyLevel         (INTEGER — message-notify level; 1 = notify
+ *                               normally, other values (observed 4) = 免打扰/muted)
  *
  * The 40051 column is decoded by `@weq/codec`; chatType is mapped through the
  * codec's ChatType enum. Everything is assembled into `RecentContact`.
@@ -26,7 +28,7 @@ import type { DatabaseAlgorithms, NtHelperBinding, SqlRow, SqlValue } from '@weq
 import type { RecentContact } from './types';
 import { QqDb } from '../qq_db';
 
-const SELECT_COLUMNS = `"40003","40010","40020","40021","40030","40050","40051","40090","40093","40094","40095","41110","41135"`;
+const SELECT_COLUMNS = `"40003","40010","40020","40021","40030","40050","40051","40090","40093","40094","40095","41110","41135","41220"`;
 const contactCodec = new ProtoMsg(RecentContactBody);
 
 /**
@@ -91,6 +93,7 @@ function rowToRecentContact(row: SqlRow): RecentContact {
     senderRemark: toStr(row[10]),
     targetAvatar: toStr(row[11]),
     targetRemark: toStr(row[12]),
+    notifyLevel: toNum(row[13]),
   };
 }
 

--- a/packages/db/src/contact/types.ts
+++ b/packages/db/src/contact/types.ts
@@ -38,4 +38,10 @@ export interface RecentContact {
   targetAvatar: string;
   /** 41135 — conversation remark name. */
   targetRemark: string;
+  /**
+   * 41220 — message-notify level. 1 = notify normally; other values
+   * (observed 4) mean 免打扰/muted. Consumers derive a boolean from this
+   * (see the renderer's mute resolution).
+   */
+  notifyLevel: number;
 }

--- a/packages/db/src/msg/c2c.ts
+++ b/packages/db/src/msg/c2c.ts
@@ -105,19 +105,19 @@ export class C2cMsgDb {
   }
 
   /**
-   * The page of messages just newer than `afterRowId` (exclusive), ordered by
-   * rowid ASC. The export-only fallback for conversations whose `40003` msgSeq
-   * is unusable (all 0/NULL — e.g. history imported by a phone migration that
-   * didn't rebuild the per-peer seq): the seq cursor matches nothing there, so
-   * we page by the always-present, monotonic-on-insert rowid instead. rowid is
-   * insertion order, only an *approximation* of true send-time order — hence
-   * fallback-only, never the primary path.
+   * The page of **seq-less** messages (40003 = 0 / NULL) just newer than
+   * `afterRowId` (exclusive), ordered by rowid ASC. Export-only: phone→PC
+   * migrated history lands with no per-peer seq, so the normal `40003 > ?`
+   * cursor never sees it. Those rows still carry a real sendTime, so the export
+   * merges this rowid-ordered stream (insertion order ≈ send-time order for a
+   * migrated block) against the seq stream by sendTime — see `message_source`.
+   * Restricting to seq-less rows keeps the two streams disjoint (no dupes).
    */
-  async listAfterRowId(part: C2cPartition, afterRowId: bigint, limit = 50): Promise<Array<C2cMsg & { rowId: bigint }>> {
+  async listSeqlessAfterRowId(part: C2cPartition, afterRowId: bigint, limit = 50): Promise<Array<C2cMsg & { rowId: bigint }>> {
     const { clause, value } = partitionWhere(part);
     const rows = await this.qq.query(
       `SELECT rowid, ${SELECT_COLUMNS} FROM ${this.table}
-        WHERE ${clause} AND rowid > ?
+        WHERE ${clause} AND rowid > ? AND ("40003" = 0 OR "40003" IS NULL)
         ORDER BY rowid ASC
         LIMIT ?`,
       [value, afterRowId, BigInt(limit)],

--- a/packages/db/src/msg/c2c.ts
+++ b/packages/db/src/msg/c2c.ts
@@ -188,6 +188,63 @@ export class C2cMsgDb {
   }
 
   /**
+   * Reversible soft-delete: hide a message from its conversation without
+   * dropping the row. XOR `mask` (a high bit, far above any real sortNo) into
+   * the indexed partition key 40027 so the fast-path query `WHERE "40027" =
+   * sortNo` no longer matches, AND prefix the TEXT key 40021 with `uidPrefix`
+   * so the uid-fallback / dataline query `WHERE "40021" = uid` misses it too.
+   * The `("40027" & mask) = 0` guard makes it idempotent. Returns affected rows.
+   */
+  async softDelete(msgId: bigint, mask: bigint, uidPrefix: string): Promise<number> {
+    return this.qq.write(
+      // SQLite has no `^` (XOR) operator; use the identity a^b = (a|b) - (a&b).
+      `UPDATE ${this.table}
+          SET "40027" = ("40027" | ?) - ("40027" & ?), "40021" = ? || "40021"
+        WHERE "40001" = ? AND ("40027" & ?) = 0`,
+      [mask, mask, uidPrefix, msgId, mask],
+    );
+  }
+
+  /**
+   * List the soft-deleted messages of one peer, newest-first. A {@link softDelete}
+   * always prefixes the TEXT key 40021 with `uidPrefix` (on both the c2c and
+   * dataline tables), so a single equality on the prefixed uid finds exactly the
+   * rows hidden from this conversation — the mask bit on 40027 is left implicit.
+   * Returns them shaped like any other page (seq 40003 is untouched by delete).
+   */
+  async listDeleted(uid: string, uidPrefix: string, limit = 200): Promise<C2cMsg[]> {
+    const rows = await this.qq.query(
+      `SELECT ${SELECT_COLUMNS} FROM ${this.table}
+        WHERE "40021" = ?
+        ORDER BY "40003" DESC
+        LIMIT ?`,
+      [uidPrefix + uid, BigInt(limit)],
+    );
+    return rows.map(rowToC2cMsg);
+  }
+
+  /** Reverse {@link softDelete}: XOR 40027 back and strip the 40021 prefix. */
+  async restore(msgId: bigint, mask: bigint, uidPrefix: string): Promise<number> {
+    return this.qq.write(
+      // SQLite has no `^` (XOR) operator; use the identity a^b = (a|b) - (a&b).
+      `UPDATE ${this.table}
+          SET "40027" = ("40027" | ?) - ("40027" & ?),
+              "40021" = CASE WHEN "40021" LIKE ? THEN SUBSTR("40021", ?) ELSE "40021" END
+        WHERE "40001" = ? AND ("40027" & ?) <> 0`,
+      [mask, mask, uidPrefix + '%', BigInt(uidPrefix.length + 1), msgId, mask],
+    );
+  }
+
+  /**
+   * Hard-delete: physically drop the row (by msgId 40001) from this table. Unlike
+   * {@link softDelete} this is irreversible — the message is gone, not hidden.
+   * Returns affected rows (0 if this table doesn't hold the msgId).
+   */
+  async hardDelete(msgId: bigint): Promise<number> {
+    return this.qq.write(`DELETE FROM ${this.table} WHERE "40001" = ?`, [msgId]);
+  }
+
+  /**
    * Append a new private-chat message by cloning the peer's newest row as a
    * template (see {@link appendClonedRow}). Returns the new msgId/msgSeq, or
    * null if the conversation has no message to clone.

--- a/packages/db/src/msg/group.ts
+++ b/packages/db/src/msg/group.ts
@@ -191,6 +191,55 @@ export class GroupMsgDb {
   }
 
   /**
+   * Reversible soft-delete: XOR `mask` (a high bit, far above any real group
+   * code) into the partition key 40027 so `WHERE "40027" = groupCode` no longer
+   * matches — the message leaves the group view but the row stays. Idempotent
+   * via the `("40027" & mask) = 0` guard. Returns affected rows.
+   */
+  async softDeleteMsg(msgId: bigint, mask: bigint): Promise<number> {
+    return this.qq.write(
+      // SQLite has no `^` (XOR) operator; use the identity a^b = (a|b) - (a&b).
+      `UPDATE group_msg_table SET "40027" = ("40027" | ?) - ("40027" & ?) WHERE "40001" = ? AND ("40027" & ?) = 0`,
+      [mask, mask, msgId, mask],
+    );
+  }
+
+  /**
+   * List the soft-deleted messages of one group, newest-first. {@link softDeleteMsg}
+   * XORs `mask` into the numeric partition key 40027, so the hidden rows sit at
+   * `groupCode ^ mask`; querying that exact value returns exactly them. Their seq
+   * (40003) is untouched, so they page in normal newest-first order.
+   */
+  async listDeleted(targetGroupCode: string, mask: bigint, limit = 200): Promise<GroupMsg[]> {
+    const rows = await this.qq.query(
+      `SELECT ${SELECT_COLUMNS} FROM group_msg_table
+        WHERE "40027" = ?
+        ORDER BY "40003" DESC
+        LIMIT ?`,
+      [BigInt(targetGroupCode) ^ mask, BigInt(limit)],
+    );
+    return rows.map(rowToGroupMsg);
+  }
+
+  /** Reverse {@link softDeleteMsg}: XOR the partition key 40027 back. */
+  async restoreMsg(msgId: bigint, mask: bigint): Promise<number> {
+    return this.qq.write(
+      // SQLite has no `^` (XOR) operator; use the identity a^b = (a|b) - (a&b).
+      `UPDATE group_msg_table SET "40027" = ("40027" | ?) - ("40027" & ?) WHERE "40001" = ? AND ("40027" & ?) <> 0`,
+      [mask, mask, msgId, mask],
+    );
+  }
+
+  /**
+   * Hard-delete: physically drop the row (by msgId 40001) from group_msg_table.
+   * Unlike {@link softDeleteMsg} this is irreversible — the message is gone, not
+   * hidden. Returns affected rows (0 if the group table doesn't hold the msgId).
+   */
+  async hardDeleteMsg(msgId: bigint): Promise<number> {
+    return this.qq.write(`DELETE FROM group_msg_table WHERE "40001" = ?`, [msgId]);
+  }
+
+  /**
    * Append a new group message by cloning the group's newest row as a template
    * (see {@link appendClonedRow}). Returns the new msgId/msgSeq, or null if the
    * group has no message to clone.

--- a/packages/db/src/msg/group.ts
+++ b/packages/db/src/msg/group.ts
@@ -110,17 +110,18 @@ export class GroupMsgDb {
   }
 
   /**
-   * The page of messages just newer than `afterRowId` (exclusive), ordered by
-   * rowid ASC. The export-only fallback for conversations whose `40003` msgSeq
-   * is unusable (all 0/NULL — e.g. migration-imported history): the seq cursor
-   * matches nothing, so we page by the always-present, monotonic-on-insert
-   * rowid. rowid is insertion order — only an approximation of true send-time
-   * order, hence fallback-only.
+   * The page of **seq-less** messages (40003 = 0 / NULL) just newer than
+   * `afterRowId` (exclusive), ordered by rowid ASC. Export-only: migration-
+   * imported history lands with no per-group seq, so the normal `40003 > ?`
+   * cursor never sees it. Those rows keep a real sendTime, so the export merges
+   * this rowid-ordered stream (insertion order ≈ send-time order for an imported
+   * block) against the seq stream by sendTime — see `message_source`. Restricting
+   * to seq-less rows keeps the two streams disjoint (no dupes).
    */
-  async listAfterRowId(targetGroupCode: string, afterRowId: bigint, limit = 50): Promise<Array<GroupMsg & { rowId: bigint }>> {
+  async listSeqlessAfterRowId(targetGroupCode: string, afterRowId: bigint, limit = 50): Promise<Array<GroupMsg & { rowId: bigint }>> {
     const rows = await this.qq.query(
       `SELECT rowid, ${SELECT_COLUMNS} FROM group_msg_table
-        WHERE "40027" = ? AND rowid > ?
+        WHERE "40027" = ? AND rowid > ? AND ("40003" = 0 OR "40003" IS NULL)
         ORDER BY rowid ASC
         LIMIT ?`,
       [targetGroupCode, afterRowId, BigInt(limit)],

--- a/packages/db/src/msg/unread_info.ts
+++ b/packages/db/src/msg/unread_info.ts
@@ -18,16 +18,36 @@ export interface UnreadInfoDbOptions {
 }
 
 /**
- * 特别关心 (special-care) marker for a conversation, decoded from the 48902
- * notify-highlight extension (50005 → 50060, kind 1006). Present only when the
- * conversation has an unread message from a 特别关心 friend.
+ * Named categories of the 48902 notify-highlight (50005 → 50060), keyed by the
+ * observed `50000` kind code. QQ NT populates one highlight group per category
+ * that currently has an unread hit:
+ *   1000 = @我 (at-me), 1006 = 特别关心 (special-care),
+ *   2000 = @全体 (at-all), 2001 = 新文件 (new-file).
+ * More (回复我 …) will slot in as their codes are captured.
  */
-export interface SpecialCareInfo {
-  /** Seq of the (latest) special-care message. */
+export type HighlightKind = 'atMe' | 'atAll' | 'specialCare' | 'newFile' | 'unknown';
+
+const HIGHLIGHT_KIND_BY_CODE: Record<number, HighlightKind> = {
+  1000: 'atMe',
+  1006: 'specialCare',
+  2000: 'atAll',
+  2001: 'newFile',
+};
+
+/**
+ * One notify-highlight hit for a conversation, decoded from 50060 → 50040.
+ * Present only while the conversation has a matching unread message.
+ */
+export interface UnreadHighlight {
+  /** Mapped category; 'unknown' when the 50000 code isn't recognized yet. */
+  kind: HighlightKind;
+  /** Raw 50000 code, preserved so unmapped categories are still identifiable. */
+  rawKind: number;
+  /** Seq of the (latest) highlighted message in this category. */
   msgSeq: number;
-  /** Uid of the special-care sender. */
+  /** Uid of the sender. */
   senderUid: string;
-  /** Send time of the special-care message (unix seconds). */
+  /** Send time of the highlighted message (unix seconds). */
   sendTime: number;
 }
 
@@ -36,12 +56,9 @@ export interface UnreadInfoResult {
   chatType: number;
   uid: string;
   msgSeq?: number;
-  /** 特别关心 marker, when the conversation has a special-care unread. */
-  specialCare?: SpecialCareInfo;
+  /** Notify-highlights (特别关心 / @我 / …) present on this conversation. */
+  highlights?: UnreadHighlight[];
 }
-
-/** QQ NT's notify-highlight kind code for 特别关心. */
-const HIGHLIGHT_KIND_SPECIAL_CARE = 1006;
 
 export class UnreadInfoDb {
   private readonly qq: QqDb;
@@ -63,13 +80,14 @@ export class UnreadInfoDb {
 
     const buf = row[1] as Uint8Array;
     const decoded = buf ? this.proto.decode(buf) : {};
+    const highlights = extractHighlights(decoded.info?.ext);
 
     return {
       peer: row[0] as string,
       chatType,
       uid,
       msgSeq: decoded.info?.msgSeq,
-      specialCare: extractSpecialCare(decoded.info?.ext),
+      highlights: highlights.length ? highlights : undefined,
     };
   }
 
@@ -78,32 +96,36 @@ export class UnreadInfoDb {
   }
 }
 
-/**
- * Pull the 特别关心 marker out of the decoded 50005 extension. Picks the
- * highlight group tagged with the special-care kind and returns its latest
- * (highest-seq) item. Returns undefined when there's no special-care unread.
- */
 type DecodedExt = NonNullable<
   NonNullable<ReturnType<ProtoMsg<typeof UnreadInfo>['decode']>['info']>['ext']
 >;
 
-function extractSpecialCare(ext: DecodedExt | undefined): SpecialCareInfo | undefined {
+/**
+ * Flatten the 50060 highlight groups into one entry per category. Each group's
+ * `50000` code maps to a `HighlightKind`; within a group the latest (highest
+ * seq) 50040 item wins.
+ */
+function extractHighlights(ext: DecodedExt | undefined): UnreadHighlight[] {
   const groups = ext?.highlight;
-  if (!groups?.length) return undefined;
+  if (!groups?.length) return [];
 
-  let best: SpecialCareInfo | undefined;
+  const out: UnreadHighlight[] = [];
   for (const group of groups) {
-    if (group.kind !== HIGHLIGHT_KIND_SPECIAL_CARE) continue;
+    const rawKind = group.kind ?? -1;
+    let best: UnreadHighlight | undefined;
     for (const item of group.items ?? []) {
       if (item.msgSeq === undefined) continue;
       if (!best || item.msgSeq > best.msgSeq) {
         best = {
+          kind: HIGHLIGHT_KIND_BY_CODE[rawKind] ?? 'unknown',
+          rawKind,
           msgSeq: item.msgSeq,
           senderUid: item.senderUid ?? '',
           sendTime: item.sendTime ?? 0,
         };
       }
     }
+    if (best) out.push(best);
   }
-  return best;
+  return out;
 }

--- a/packages/db/src/msg/unread_info.ts
+++ b/packages/db/src/msg/unread_info.ts
@@ -21,15 +21,22 @@ export interface UnreadInfoDbOptions {
  * Named categories of the 48902 notify-highlight (50005 → 50060), keyed by the
  * observed `50000` kind code. QQ NT populates one highlight group per category
  * that currently has an unread hit:
- *   1000 = @我 (at-me), 1006 = 特别关心 (special-care),
+ *   1000 = @我 (at-me), 1006 = 特别关心 (special-care), 1007 = QQ红包 (red-packet),
  *   2000 = @全体 (at-all), 2001 = 新文件 (new-file).
  * More (回复我 …) will slot in as their codes are captured.
  */
-export type HighlightKind = 'atMe' | 'atAll' | 'specialCare' | 'newFile' | 'unknown';
+export type HighlightKind =
+  | 'atMe'
+  | 'atAll'
+  | 'specialCare'
+  | 'newFile'
+  | 'redPacket'
+  | 'unknown';
 
 const HIGHLIGHT_KIND_BY_CODE: Record<number, HighlightKind> = {
   1000: 'atMe',
   1006: 'specialCare',
+  1007: 'redPacket',
   2000: 'atAll',
   2001: 'newFile',
 };

--- a/packages/db/src/msg/unread_info.ts
+++ b/packages/db/src/msg/unread_info.ts
@@ -17,12 +17,31 @@ export interface UnreadInfoDbOptions {
   algo?: DatabaseAlgorithms;
 }
 
+/**
+ * 特别关心 (special-care) marker for a conversation, decoded from the 48902
+ * notify-highlight extension (50005 → 50060, kind 1006). Present only when the
+ * conversation has an unread message from a 特别关心 friend.
+ */
+export interface SpecialCareInfo {
+  /** Seq of the (latest) special-care message. */
+  msgSeq: number;
+  /** Uid of the special-care sender. */
+  senderUid: string;
+  /** Send time of the special-care message (unix seconds). */
+  sendTime: number;
+}
+
 export interface UnreadInfoResult {
   peer: string;
   chatType: number;
   uid: string;
   msgSeq?: number;
+  /** 特别关心 marker, when the conversation has a special-care unread. */
+  specialCare?: SpecialCareInfo;
 }
+
+/** QQ NT's notify-highlight kind code for 特别关心. */
+const HIGHLIGHT_KIND_SPECIAL_CARE = 1006;
 
 export class UnreadInfoDb {
   private readonly qq: QqDb;
@@ -50,10 +69,41 @@ export class UnreadInfoDb {
       chatType,
       uid,
       msgSeq: decoded.info?.msgSeq,
+      specialCare: extractSpecialCare(decoded.info?.ext),
     };
   }
 
   close(): void {
     this.qq.close();
   }
+}
+
+/**
+ * Pull the 特别关心 marker out of the decoded 50005 extension. Picks the
+ * highlight group tagged with the special-care kind and returns its latest
+ * (highest-seq) item. Returns undefined when there's no special-care unread.
+ */
+type DecodedExt = NonNullable<
+  NonNullable<ReturnType<ProtoMsg<typeof UnreadInfo>['decode']>['info']>['ext']
+>;
+
+function extractSpecialCare(ext: DecodedExt | undefined): SpecialCareInfo | undefined {
+  const groups = ext?.highlight;
+  if (!groups?.length) return undefined;
+
+  let best: SpecialCareInfo | undefined;
+  for (const group of groups) {
+    if (group.kind !== HIGHLIGHT_KIND_SPECIAL_CARE) continue;
+    for (const item of group.items ?? []) {
+      if (item.msgSeq === undefined) continue;
+      if (!best || item.msgSeq > best.msgSeq) {
+        best = {
+          msgSeq: item.msgSeq,
+          senderUid: item.senderUid ?? '',
+          sendTime: item.sendTime ?? 0,
+        };
+      }
+    }
+  }
+  return best;
 }

--- a/packages/db/src/qq_db.ts
+++ b/packages/db/src/qq_db.ts
@@ -65,12 +65,25 @@ export class QqDb {
    *
    * ⚠️ Writes go to QQ's live database. Always back up first and prefer to
    *    run with QQ fully closed.
+   *
+   * The native layer keeps a cached connection per dbPath, and a write
+   * connection holds SQLite's RESERVED/EXCLUSIVE lock. If we left it open,
+   * QQ itself would be locked out of nt_msg.db ("database is locked" — no
+   * chat history, no contacts) until WeQ exits. And if the write throws
+   * (e.g. a SQL error), the half-acquired lock would otherwise stay held.
+   * So we ALWAYS drop the connection afterwards — releasing the lock back to
+   * QQ. Writes here are low-frequency (delete / edit / insert), so the
+   * re-open + re-decrypt on the next query is a non-issue.
    */
-  write(sql: string, params?: SqlValue[]): Promise<number> {
-    if (this.encrypted) {
-      return this.nt.executeSqlWriteWithKey(this.dbPath, sql, this.key!, this.algo!, params ?? null);
+  async write(sql: string, params?: SqlValue[]): Promise<number> {
+    try {
+      if (this.encrypted) {
+        return await this.nt.executeSqlWriteWithKey(this.dbPath, sql, this.key!, this.algo!, params ?? null);
+      }
+      return await this.nt.executeSqlWrite(this.dbPath, sql, params ?? null);
+    } finally {
+      this.nt.closeDb(this.dbPath);
     }
-    return this.nt.executeSqlWrite(this.dbPath, sql, params ?? null);
   }
 
   /** Drop both the read and write cached native connections for this database. */

--- a/packages/db/test/dump_msg_by_id.ts
+++ b/packages/db/test/dump_msg_by_id.ts
@@ -1,0 +1,117 @@
+/**
+ * Dump every column of a single message row by msgId (40001), across both the
+ * c2c and group message tables, showing the raw value AND its SQLite storage
+ * class. Built to debug soft-delete: it flags whether the 40027 mask bit
+ * (1<<62) is set and whether 40021 carries the `weqdel` prefix.
+ *
+ * Run:  pnpm tsx ./packages/db/test/dump_msg_by_id.ts <msgId> [<msgId> ...]
+ *   or  WEQ_TEST_MSG_IDS="7651461878938216377,7661671524070269822" pnpm tsx ./packages/db/test/dump_msg_by_id.ts
+ *
+ * Path/key are hard-coded below (override with WEQ_TEST_DB_PATH / WEQ_TEST_DB_KEY).
+ */
+
+import { loadNative } from '@weq/native';
+import { QqDb } from '../src/qq_db';
+
+// ── hard-coded dev credentials (edit these to your local account) ────────────
+const DB_PATH =
+  process.env.WEQ_TEST_DB_PATH ??
+  String.raw`D:\estkim\T\Tencent Files\1707889225\nt_qq\nt_db\nt_msg.db`;
+const KEY = process.env.WEQ_TEST_DB_KEY ?? '^;<kXZ;RI[@]yTD<';
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Same mask the service uses (SOFT_DELETE_MASK = bit 62). */
+const SOFT_DELETE_MASK = 1n << 62n;
+const SOFT_DELETE_UID_PREFIX = 'weqdel';
+
+const TABLES = ['c2c_msg_table', 'group_msg_table'] as const;
+
+function storageClass(v: unknown): string {
+  if (v === null || v === undefined) return 'NULL';
+  if (v instanceof Uint8Array) return 'BLOB';
+  if (typeof v === 'bigint') return 'INTEGER';
+  if (typeof v === 'number') return Number.isInteger(v) ? 'INTEGER' : 'REAL';
+  if (typeof v === 'string') return 'TEXT';
+  return typeof v;
+}
+
+function describe(v: unknown): string {
+  if (v === null || v === undefined) return String(v);
+  if (v instanceof Uint8Array) return `<BLOB ${v.byteLength} bytes>`;
+  if (typeof v === 'bigint') return `${v}n`;
+  if (typeof v === 'string') return v.length > 120 ? `${v.slice(0, 120)}… (${v.length} chars)` : JSON.stringify(v);
+  return String(v);
+}
+
+async function dumpRow(db: QqDb, table: string, msgId: bigint): Promise<void> {
+  const info = await db.query(`PRAGMA table_info("${table}")`);
+  const cols = info.map((r) => `"${String(r[1])}"`).join(',');
+  const rows = await db.query(`SELECT ${cols} FROM "${table}" WHERE "40001" = ? LIMIT 1`, [msgId]);
+
+  if (rows.length === 0) {
+    console.log(`  (not found in ${table})`);
+    return;
+  }
+  const row = rows[0]!;
+  info.forEach((r, i) => {
+    const name = String(r[1]);
+    const val = row[i];
+    let note = '';
+    if (name === '40027') {
+      // Is the delete mask bit set?
+      let asInt: bigint | null = null;
+      try { asInt = typeof val === 'bigint' ? val : BigInt(String(val)); } catch { asInt = null; }
+      if (asInt !== null) {
+        const masked = (asInt & SOFT_DELETE_MASK) !== 0n;
+        note = masked
+          ? `  ⚠️  MASK BIT SET (deleted) — original = ${asInt ^ SOFT_DELETE_MASK}`
+          : `  ✅ clean (mask bit not set)`;
+      }
+    }
+    if (name === '40021' && typeof val === 'string') {
+      note = val.startsWith(SOFT_DELETE_UID_PREFIX)
+        ? `  ⚠️  has "${SOFT_DELETE_UID_PREFIX}" prefix (deleted)`
+        : `  ✅ no delete prefix`;
+    }
+    console.log(`    ${name.padEnd(8)} [${storageClass(val).padEnd(7)}] = ${describe(val)}${note}`);
+  });
+}
+
+async function main(): Promise<void> {
+  const idsArg = process.argv.slice(2).join(',') || process.env.WEQ_TEST_MSG_IDS || '';
+  const ids = idsArg
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => BigInt(s));
+
+  if (ids.length === 0) {
+    console.error('usage: pnpm tsx ./packages/db/test/dump_msg_by_id.ts <msgId> [<msgId> ...]');
+    process.exit(1);
+  }
+
+  const native = loadNative();
+  const db = new QqDb(native.ntHelper, {
+    dbPath: DB_PATH,
+    key: KEY,
+    algo: { pageHmacAlgorithm: 'SHA1', kdfHmacAlgorithm: 'SHA512' },
+  });
+
+  console.log(`[dump-msg] opening ${DB_PATH}`);
+  console.log(`[dump-msg] mask = ${SOFT_DELETE_MASK} (bit 62), uidPrefix = "${SOFT_DELETE_UID_PREFIX}"\n`);
+
+  for (const id of ids) {
+    console.log(`\n════════════ msgId ${id} ════════════`);
+    for (const table of TABLES) {
+      console.log(`\n  ── ${table} ──`);
+      await dumpRow(db, table, id);
+    }
+  }
+
+  db.close();
+}
+
+main().catch((e) => {
+  console.error('[dump-msg] failed:', e);
+  process.exit(1);
+});

--- a/packages/db/test/dump_profile_info.ts
+++ b/packages/db/test/dump_profile_info.ts
@@ -1,0 +1,88 @@
+/**
+ * 实测 profile_info_v6：陌生人（非好友）到底存了哪些字段。
+ *
+ * Run:  pnpm tsx ./packages/db/test/dump_profile_info.ts
+ */
+
+import { loadNative } from '@weq/native';
+import { QqDb } from '../src/qq_db';
+
+const UIN_ME = '1707889225';
+const DB_PATH =
+  process.env.WEQ_TEST_PROFILE_DB_PATH ??
+  `D:\\estkim\\T\\Tencent Files\\${UIN_ME}\\nt_qq\\nt_db\\profile_info.db`;
+const KEY = process.env.WEQ_TEST_DB_KEY ?? '^;<kXZ;RI[@]yTD<';
+
+const TABLE = 'profile_info_v6';
+
+function log(msg: string): void {
+  console.error(msg); // stderr：无缓冲，卡住也能看到进度
+}
+
+function describe(v: unknown): string {
+  if (v === null || v === undefined) return String(v);
+  if (v instanceof Uint8Array) {
+    const hex = Buffer.from(v).toString('hex');
+    return `<BLOB ${v.byteLength}b> ${hex.length > 120 ? hex.slice(0, 120) + '…' : hex}`;
+  }
+  if (typeof v === 'bigint') return `${v}n`;
+  if (typeof v === 'string') return v.length > 160 ? `"${v.slice(0, 160)}…"` : `"${v}"`;
+  return `${String(v)}`;
+}
+
+async function dumpRow(db: QqDb, cols: string[], where: string): Promise<void> {
+  const rows = await db.query(`SELECT * FROM "${TABLE}" WHERE ${where} LIMIT 1`);
+  const row = rows[0];
+  if (!row) {
+    log(`  (no row for ${where})`);
+    return;
+  }
+  for (let i = 0; i < cols.length; i++) {
+    log(`  ${(cols[i] ?? `#${i}`).padEnd(8)} = ${describe(row[i])}`);
+  }
+}
+
+async function main(): Promise<void> {
+  log('[1] loadNative…');
+  const native = loadNative();
+  log('[2] open db…');
+  const db = new QqDb(native.ntHelper, {
+    dbPath: DB_PATH,
+    key: KEY,
+    algo: { pageHmacAlgorithm: 'SHA1', kdfHmacAlgorithm: 'SHA512' },
+  });
+
+  log('[3] PRAGMA table_info…');
+  const info = await db.query(`PRAGMA table_info("${TABLE}")`);
+  log(`\n== ${TABLE} columns (${info.length}) ==`);
+  for (const row of info) {
+    log(`  ${String(row[1]).padEnd(8)} ${String(row[2] || '').padEnd(10)} pk=${row[5]}`);
+  }
+  const cols = info.map((r) => String(r[1]));
+
+  log('[4] counts…');
+  const total = (await db.query(`SELECT COUNT(*) FROM "${TABLE}"`))[0]?.[0];
+  const withRel = (await db.query(`SELECT COUNT(*) FROM "${TABLE}" WHERE "20072" IS NOT NULL`))[0]?.[0];
+  const noRel = (await db.query(`SELECT COUNT(*) FROM "${TABLE}" WHERE "20072" IS NULL`))[0]?.[0];
+  log(`  总行数=${total}  有密友关系(好友)=${withRel}  无20072(陌生人)=${noRel}`);
+
+  log('[5] 陌生人样本 (20072 IS NULL, 取3行)…');
+  const strangers = await db.query(`SELECT "1000" FROM "${TABLE}" WHERE "20072" IS NULL LIMIT 3`);
+  if (strangers.length === 0) log('  (没有 20072 为空的行 —— 这表几乎只存好友!)');
+  for (const s of strangers) {
+    const uid = String(s[0]);
+    log(`\n---- 陌生人 uid=${uid} ----`);
+    await dumpRow(db, cols, `"1000" = '${uid}'`);
+  }
+
+  log('\n[6] 好友样本 (20072 IS NOT NULL)…');
+  await dumpRow(db, cols, `"20072" IS NOT NULL`);
+
+  log('[done]');
+  db.close();
+}
+
+main().catch((e) => {
+  console.error('[dump-profile-info] failed:', e);
+  process.exit(1);
+});

--- a/packages/db/test/inspect_redpacket.ts
+++ b/packages/db/test/inspect_redpacket.ts
@@ -61,7 +61,7 @@ function printTree(fields: RawField[], indent: string): void {
       if (asStr && asStr.kind === 'len-utf8' && asStr.value.trim()) {
         console.log(`${indent}    (也可读作 ${topGuess(asStr)})`);
       }
-    } else {
+    } else if (best) {
       console.log(`${indent}#${f.tag}  ${topGuess(best)}`);
     }
   }

--- a/packages/db/test/inspect_redpacket.ts
+++ b/packages/db/test/inspect_redpacket.ts
@@ -1,0 +1,99 @@
+/**
+ * 对比「专属红包」与「普通拼手气红包」的 wallet element 原始字段，
+ * 找出指定领取群友 id 所在的字段。
+ *
+ * Run:  pnpm --filter @weq/db exec tsx test/inspect_redpacket.ts
+ */
+
+import { loadNative } from '@weq/native';
+import { decode, type RawField, type Guess } from '@weq/codec/raw';
+import { GroupMsgDb } from '../src/msg/group';
+
+const DB_PATH =
+  process.env.WEQ_TEST_DB_PATH ??
+  String.raw`D:\estkim\T\Tencent Files\1707889225\nt_qq\nt_db\nt_msg.db`;
+const KEY = process.env.WEQ_TEST_DB_KEY ?? '^;<kXZ;RI[@]yTD<';
+
+const CASES: Array<{ label: string; msgId: bigint }> = [
+  { label: '专属红包 (给指定群友)', msgId: 7661607490431795174n },
+  { label: '普通拼手气红包', msgId: 7661606365443025303n },
+];
+
+/** 从一个字段挑选最能代表其内容的一个 guess，输出精简描述。 */
+function topGuess(g: Guess): string {
+  switch (g.kind) {
+    case 'varint-uint64':
+      return `uint64=${g.value}`;
+    case 'varint-bool':
+      return `bool=${g.value}`;
+    case 'varint-timestamp-ms':
+    case 'varint-timestamp-sec':
+      return `time=${g.value.toISOString()}`;
+    case 'varint-int64-zigzag':
+      return `zigzag=${g.value}`;
+    case 'i64-fixed':
+      return `i64=${g.value}`;
+    case 'i64-double':
+      return `f64=${g.value}`;
+    case 'i32-fixed':
+      return `i32=${g.value}`;
+    case 'i32-float':
+      return `f32=${g.value}`;
+    case 'len-utf8':
+      return `str=${JSON.stringify(g.value)}`;
+    case 'len-bytes':
+      return `bytes[${g.value.length}]=${Buffer.from(g.value).toString('hex').slice(0, 48)}`;
+    case 'len-nested':
+      return `nested(${g.value.length} fields)`;
+  }
+}
+
+function printTree(fields: RawField[], indent: string): void {
+  for (const f of fields) {
+    // guesses 已按 confidence 降序；取最高置信一条作为主展示
+    const best = f.guesses[0];
+    const nested = f.guesses.find((g) => g.kind === 'len-nested');
+    if (nested && nested.kind === 'len-nested') {
+      console.log(`${indent}#${f.tag}  ${topGuess(nested)}`);
+      printTree(nested.value, indent + '  ');
+      // 若同一 LEN 字段还能被解释成字符串，附注一下
+      const asStr = f.guesses.find((g) => g.kind === 'len-utf8');
+      if (asStr && asStr.kind === 'len-utf8' && asStr.value.trim()) {
+        console.log(`${indent}    (也可读作 ${topGuess(asStr)})`);
+      }
+    } else {
+      console.log(`${indent}#${f.tag}  ${topGuess(best)}`);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const native = loadNative();
+  const db = new GroupMsgDb(native.ntHelper, {
+    dbPath: DB_PATH,
+    key: KEY,
+    algo: { pageHmacAlgorithm: 'SHA1', kdfHmacAlgorithm: 'SHA512' },
+  });
+
+  for (const c of CASES) {
+    console.log('\n' + '='.repeat(70));
+    console.log(`${c.label}  msgId=${c.msgId}`);
+    console.log('='.repeat(70));
+
+    const body = await db.getMsgBody(c.msgId);
+    if (!body) {
+      console.log('  (未找到该 msgId 的 msgBody)');
+      continue;
+    }
+    console.log(`msgBody ${body.length} bytes\n`);
+    const fields = decode(body);
+    printTree(fields, '');
+  }
+
+  db.close();
+}
+
+main().catch((e) => {
+  console.error('[inspect_redpacket] failed:', e);
+  process.exit(1);
+});

--- a/packages/db/test/verify_avatar_hash.ts
+++ b/packages/db/test/verify_avatar_hash.ts
@@ -1,0 +1,130 @@
+/**
+ * Verify the avatar-path hash formula against real `recent_contact_v3_table`
+ * rows.
+ *
+ * Claim: the local avatar file at `nt_data/avatar/<scope>/<bucket>/[b_|s_]<hash>`
+ * has
+ *
+ *     hash   = md5( md5( md5(uid) + uid ) + uid )         // hex-string concat
+ *     bucket = hash.slice(0, 2)
+ *
+ * where `uid` is the account uid (`u_xxx` for users; the numeric uin for groups,
+ * since group uin == uid). We read the (uid, avatarPath) pair straight out of
+ * recent_contact — 40021 = targetUid, 41110 = targetAvatar — recompute the hash,
+ * and check it against the hash embedded in the stored path.
+ *
+ * Run:  pnpm --filter @weq/db test:verify-avatar-hash
+ */
+
+import { createHash } from 'node:crypto';
+import { statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { loadNative } from '@weq/native';
+import { QqDb } from '../src/qq_db';
+
+const DB_PATH =
+  process.env.WEQ_TEST_DB_PATH ??
+  String.raw`D:\estkim\T\Tencent Files\1707889225\nt_qq\nt_db\nt_msg.db`;
+const KEY = process.env.WEQ_TEST_DB_KEY ?? '^;<kXZ;RI[@]yTD<';
+
+const TABLE = 'recent_contact_v3_table';
+
+/** md5 hex digest of a UTF-8 string. */
+function md5(s: string): string {
+  return createHash('md5').update(s).digest('hex');
+}
+
+/** hash = md5(md5(md5(uid)+uid)+uid) — nested, hex-string concatenation. */
+function avatarHash(uid: string): string {
+  return md5(md5(md5(uid) + uid) + uid);
+}
+
+/** Pull the `[b_|s_]<hash>` leaf out of a stored avatar path, if present. */
+function hashFromPath(path: string): string | null {
+  const leaf = path.replace(/\\/g, '/').split('/').pop() ?? '';
+  const m = /^(?:[bs]_)?([0-9a-f]{16,64})$/i.exec(leaf);
+  return m ? m[1]!.toLowerCase() : null;
+}
+
+/** …/nt_qq/nt_db/nt_msg.db → …/nt_qq/nt_data (the avatar tree's root). */
+const NT_DATA_DIR = join(dirname(dirname(DB_PATH)), 'nt_data');
+
+/** True when a file exists on disk (mirrors AvatarResourceService.resolveFile). */
+function fileExists(p: string): boolean {
+  try {
+    return statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Rebuild the on-disk path the way `resolveByUid` would — from ntData + scope +
+ * bucket + `b_`/`s_` prefix — and report which variants exist. This validates
+ * the service's path construction, not just the hash arithmetic.
+ */
+function probeLocal(scope: 'user' | 'group', hash: string): string {
+  const bucket = hash.slice(0, 2).toLowerCase();
+  const big = fileExists(join(NT_DATA_DIR, 'avatar', scope, bucket, `b_${hash}`));
+  const small = fileExists(join(NT_DATA_DIR, 'avatar', scope, bucket, `s_${hash}`));
+  return `${big ? 'b_' : '--'}${small ? 's_' : '--'}`;
+}
+
+async function main(): Promise<void> {
+  const native = loadNative();
+  const db = new QqDb(native.ntHelper, {
+    dbPath: DB_PATH,
+    key: KEY,
+    algo: { pageHmacAlgorithm: 'SHA1', kdfHmacAlgorithm: 'SHA512' },
+  });
+
+  console.log(`[verify-avatar-hash] opening ${DB_PATH}\n`);
+
+  // 40010 chatType, 40021 targetUid, 41110 targetAvatar (path).
+  const rows = await db.query(
+    `SELECT "40010","40021","41110" FROM "${TABLE}"
+       WHERE "41110" IS NOT NULL AND "41110" <> ''
+       ORDER BY "40050" DESC LIMIT 40`,
+  );
+
+  let checked = 0;
+  let matched = 0;
+
+  for (const row of rows) {
+    const chatType = String(row[0]);
+    const uid = typeof row[1] === 'string' ? row[1] : String(row[1] ?? '');
+    const path = typeof row[2] === 'string' ? row[2] : String(row[2] ?? '');
+    if (!uid) continue;
+
+    const stored = hashFromPath(path);
+    if (!stored) {
+      // Not a local nt_data/avatar path (e.g. a CDN url) — nothing to check.
+      console.log(`SKIP  chatType=${chatType} uid=${uid}\n      path=${path}`);
+      continue;
+    }
+
+    const computed = avatarHash(uid);
+    const ok = computed === stored;
+    checked += 1;
+    if (ok) matched += 1;
+
+    // chatType 2 = group (scope 'group'); everything else is a user avatar.
+    const scope = chatType === '2' ? 'group' : 'user';
+    const onDisk = probeLocal(scope, computed);
+
+    console.log(
+      `${ok ? 'OK  ' : 'FAIL'}  chatType=${chatType} scope=${scope} uid=${uid}\n` +
+        `      stored  =${stored}\n` +
+        `      computed=${computed}  onDisk=[${onDisk}]\n` +
+        `      path    =${path}`,
+    );
+  }
+
+  console.log(`\n================ ${matched}/${checked} hash matched ================`);
+  db.close();
+}
+
+main().catch((e) => {
+  console.error('[verify-avatar-hash] failed:', e);
+  process.exit(1);
+});

--- a/packages/db/test/verify_avatar_probe.ts
+++ b/packages/db/test/verify_avatar_probe.ts
@@ -1,0 +1,102 @@
+/**
+ * End-to-end check for the 头像路径 tool's FRIEND path:
+ *
+ *   uin --(profile_info_v6: 1002→1000)--> uid --(md5³)--> hash --> on-disk file
+ *
+ * We take real friend conversations from recent_contact (chatType 1, which carry
+ * both 40030 targetUin and 40021 targetUid), resolve uin→uid the way `probeByQq`
+ * does (via profile_info.db), recompute the hash, and confirm both that the
+ * resolved uid matches recent_contact's and that the derived avatar file exists.
+ *
+ * Run:  pnpm --filter @weq/db test:verify-avatar-probe
+ */
+
+import { createHash } from 'node:crypto';
+import { statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { loadNative } from '@weq/native';
+import { QqDb } from '../src/qq_db';
+
+const MSG_DB =
+  process.env.WEQ_TEST_DB_PATH ??
+  String.raw`D:\estkim\T\Tencent Files\1707889225\nt_qq\nt_db\nt_msg.db`;
+const KEY = process.env.WEQ_TEST_DB_KEY ?? '^;<kXZ;RI[@]yTD<';
+const ALGO = { pageHmacAlgorithm: 'SHA1', kdfHmacAlgorithm: 'SHA512' } as const;
+
+const PROFILE_DB = join(dirname(MSG_DB), 'profile_info.db');
+const NT_DATA_DIR = join(dirname(dirname(MSG_DB)), 'nt_data');
+
+function md5(s: string): string {
+  return createHash('md5').update(s).digest('hex');
+}
+function avatarHash(uid: string): string {
+  return md5(md5(md5(uid) + uid) + uid);
+}
+function onDisk(scope: string, hash: string): string {
+  const bucket = hash.slice(0, 2);
+  const has = (p: string): boolean => {
+    try {
+      return statSync(p).isFile();
+    } catch {
+      return false;
+    }
+  };
+  const big = has(join(NT_DATA_DIR, 'avatar', scope, bucket, `b_${hash}`));
+  const small = has(join(NT_DATA_DIR, 'avatar', scope, bucket, `s_${hash}`));
+  return `${big ? 'b_' : '--'}${small ? 's_' : '--'}`;
+}
+
+async function main(): Promise<void> {
+  const native = loadNative();
+  const msg = new QqDb(native.ntHelper, { dbPath: MSG_DB, key: KEY, algo: ALGO });
+  const profile = new QqDb(native.ntHelper, { dbPath: PROFILE_DB, key: KEY, algo: ALGO });
+
+  // Friend conversations only (chatType 1): both uin + uid present.
+  const rows = await msg.query(
+    `SELECT "40030","40021" FROM recent_contact_v3_table
+       WHERE "40010" = 1 AND "40030" IS NOT NULL AND "40030" <> 0
+       ORDER BY "40050" DESC LIMIT 20`,
+  );
+
+  let checked = 0;
+  let uidOk = 0;
+  let fileOk = 0;
+
+  for (const row of rows) {
+    const uin = typeof row[0] === 'bigint' ? row[0].toString() : String(row[0] ?? '');
+    const rcUid = typeof row[1] === 'string' ? row[1] : String(row[1] ?? '');
+    if (!/^\d+$/.test(uin)) continue;
+
+    // The exact lookup probeByQq does for a friend.
+    const pr = await profile.query(`SELECT "1000" FROM profile_info_v6 WHERE "1002" = ? LIMIT 1`, [
+      BigInt(uin),
+    ]);
+    const uid = pr.length ? String(pr[0]![0] ?? '') : '';
+
+    checked += 1;
+    const matches = uid !== '' && uid === rcUid;
+    if (matches) uidOk += 1;
+
+    const hash = uid ? avatarHash(uid) : '';
+    const disk = uid ? onDisk('user', hash) : '----';
+    if (uid && disk !== '----') fileOk += 1;
+
+    console.log(
+      `${matches ? 'OK  ' : uid ? 'DIFF' : 'MISS'}  uin=${uin}\n` +
+        `      profile.uid=${uid || '(not found)'}\n` +
+        `      rc.uid     =${rcUid}\n` +
+        (uid ? `      hash=${hash} onDisk=[${disk}]\n` : ''),
+    );
+  }
+
+  console.log(
+    `\n============ uid match ${uidOk}/${checked}, avatar on disk ${fileOk}/${checked} ============`,
+  );
+  msg.close();
+  profile.close();
+}
+
+main().catch((e) => {
+  console.error('[verify-avatar-probe] failed:', e);
+  process.exit(1);
+});

--- a/packages/db/test/verify_wallet_decode.ts
+++ b/packages/db/test/verify_wallet_decode.ts
@@ -1,0 +1,51 @@
+/**
+ * 验证 typed decode 路径能否解出 walletDesignatedUin(48420) 与 walletRedbagType(48412)。
+ * Run:  pnpm --filter @weq/db exec tsx test/verify_wallet_decode.ts
+ */
+
+import { loadNative } from '@weq/native';
+import { ProtoMsg } from '@weq/codec';
+import { decodeElement } from '@weq/codec/element';
+import { MsgBody } from '@weq/codec/proto/msg/40800';
+import { sanitizeBytes } from '@weq/codec/raw';
+import { GroupMsgDb } from '../src/msg/group';
+
+const DB_PATH =
+  process.env.WEQ_TEST_DB_PATH ??
+  String.raw`D:\estkim\T\Tencent Files\1707889225\nt_qq\nt_db\nt_msg.db`;
+const KEY = process.env.WEQ_TEST_DB_KEY ?? '^;<kXZ;RI[@]yTD<';
+
+const MSG_IDS = [7661607490431795174n, 7661606365443025303n];
+
+async function main(): Promise<void> {
+  const native = loadNative();
+  const db = new GroupMsgDb(native.ntHelper, {
+    dbPath: DB_PATH,
+    key: KEY,
+    algo: { pageHmacAlgorithm: 'SHA1', kdfHmacAlgorithm: 'SHA512' },
+  });
+  const codec = new ProtoMsg(MsgBody);
+
+  for (const msgId of MSG_IDS) {
+    const blob = await db.getMsgBody(msgId);
+    console.log('\n== msgId', msgId.toString(), '==');
+    if (!blob) {
+      console.log('  no body');
+      continue;
+    }
+    const decoded = codec.decode(sanitizeBytes(blob, MsgBody));
+    for (const w of decoded.elements ?? []) {
+      const el = decodeElement(w) as Record<string, unknown>;
+      if (el.kind !== 'wallet') continue;
+      console.log('  walletRedbagType(48412) =', el.walletRedbagType);
+      console.log('  walletDesignatedUin(48420) =', el.walletDesignatedUin);
+      console.log('  walletTargetUin(48401) =', el.walletTargetUin);
+    }
+  }
+  db.close();
+}
+
+main().catch((e) => {
+  console.error('failed:', e);
+  process.exit(1);
+});

--- a/packages/service/src/account/avatar_resource.ts
+++ b/packages/service/src/account/avatar_resource.ts
@@ -21,10 +21,26 @@
  * the `weq-media://avatar` protocol. Nothing here decrypts.
  */
 
+import { createHash } from 'node:crypto';
 import { readdir, stat } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
 import type { AccountSession } from '@weq/account';
 import type { Platform } from '@weq/platform';
+
+/**
+ * The local avatar filename hash for a peer uid:
+ *
+ *   hash = md5( md5( md5(uid) + uid ) + uid )      // hex-string concatenation
+ *
+ * so the file lives at `<scope>/<hash.slice(0,2)>/[b_|s_]<hash>`. Verified 40/40
+ * against real `recent_contact_v3_table` avatar paths (users `u_xxx`; groups use
+ * their numeric uin, which equals the uid). This is what lets us jump straight
+ * from a uid to its cached avatar file with no directory scan.
+ */
+export function avatarHashForUid(uid: string): string {
+  const md5 = (s: string): string => createHash('md5').update(s).digest('hex');
+  return md5(md5(md5(uid) + uid) + uid);
+}
 
 /** Which avatar tree to browse. */
 export type AvatarScope = 'user' | 'group' | 'cover';
@@ -66,6 +82,37 @@ export interface AvatarPage {
   entries: AvatarEntry[];
   /** Opaque cursor for the next page, or null when exhausted. */
   nextCursor: string | null;
+}
+
+/**
+ * Result of "given a QQ number, where is its avatar cached?" — the derivation
+ * behind the 头像路径 tool. Carries the resolved uid, the computed hash, and the
+ * on-disk presence of each variant so the UI can show the formula, the path,
+ * and a live preview.
+ */
+export interface AvatarPathProbe {
+  /** 'user' (friend) or 'group'. */
+  scope: AvatarScope;
+  /** The QQ number that was entered (a uin). */
+  qq: string;
+  /** Resolved peer uid (== qq for groups; '' when a friend's uid wasn't found). */
+  uid: string;
+  /** Friend remark/nick for context ('' for groups / unknown). */
+  nick: string;
+  /** True when the uid was resolved (groups: always true for a valid number). */
+  resolved: boolean;
+  /** The computed avatar hash (md5³), '' when unresolved. */
+  hash: string;
+  /** Hash bucket (first two hex chars). */
+  bucket: string;
+  /** Display path relative to nt_data: `avatar/<scope>/<bucket>/b_<hash>`. */
+  bigRel: string;
+  /** Display path relative to nt_data: `avatar/<scope>/<bucket>/s_<hash>`. */
+  smallRel: string;
+  hasBig: boolean;
+  hasSmall: boolean;
+  bigBytes: number;
+  smallBytes: number;
 }
 
 const DEFAULT_PAGE = 120;
@@ -216,6 +263,122 @@ export class AvatarResourceService {
     return null;
   }
 
+  /**
+   * Resolve a peer's local avatar straight from their uid — no directory scan.
+   * Computes the {@link avatarHashForUid} hash, then reuses {@link resolveFile}
+   * (which keeps all the bucket / temp / path-traversal handling). If the
+   * requested variant is absent we try the other one — `b_`/`s_` share the hash,
+   * so a "big" request still hits when only the thumbnail was cached. Returns
+   * null when neither is on disk, so the caller can fall back to the CDN.
+   */
+  async resolveByUid(
+    scope: AvatarScope,
+    uid: string,
+    variant: AvatarVariant,
+  ): Promise<string | null> {
+    if (!uid) return null;
+    const hash = avatarHashForUid(uid);
+    const primary = await this.resolveFile(scope, hash, variant);
+    if (primary) return primary;
+    const other: AvatarVariant = variant === 'big' ? 'small' : 'big';
+    return this.resolveFile(scope, hash, other);
+  }
+
+  /**
+   * Like {@link resolveByUid} but keyed by QQ uin. Groups have uin == uid (the
+   * numeric group code), so they resolve with no lookup; for users we translate
+   * uin → uid through the session's resident {@link UidMap}. An unknown uin
+   * (e.g. a stranger absent from the mapping table) → null → CDN fallback.
+   */
+  async resolveByUin(
+    scope: AvatarScope,
+    uin: string,
+    variant: AvatarVariant,
+  ): Promise<string | null> {
+    if (!/^\d+$/.test(uin) || uin === '0') return null;
+    if (scope === 'group') return this.resolveByUid(scope, uin, variant);
+    const uid = this.session.uidMap.uidByUin(BigInt(uin));
+    return uid ? this.resolveByUid(scope, uid, variant) : null;
+  }
+
+  /**
+   * "Given a QQ number, where is its avatar cached?" — the derivation behind the
+   * 头像路径 tool. For a friend we translate uin → uid via `profile_info_v6`
+   * (the authoritative profile table); for a group the uin IS the uid. We then
+   * compute the hash and report each variant's on-disk presence + size. Returns
+   * a probe with `resolved: false` when the number is invalid or (friend) has no
+   * cached profile row.
+   */
+  async probeByQq(kind: 'user' | 'group', qq: string): Promise<AvatarPathProbe> {
+    const scope: AvatarScope = kind === 'group' ? 'group' : 'user';
+    const blank: AvatarPathProbe = {
+      scope,
+      qq,
+      uid: '',
+      nick: '',
+      resolved: false,
+      hash: '',
+      bucket: '',
+      bigRel: '',
+      smallRel: '',
+      hasBig: false,
+      hasSmall: false,
+      bigBytes: 0,
+      smallBytes: 0,
+    };
+    if (!/^\d+$/.test(qq) || qq === '0') return blank;
+
+    let uid: string;
+    let nick = '';
+    if (kind === 'group') {
+      uid = qq; // group uin == uid
+    } else {
+      const profile = await this.session.profileInfo.getProfileByUin(BigInt(qq));
+      if (!profile || !profile.uid) return blank;
+      uid = profile.uid;
+      nick = profile.remark || profile.nick || '';
+    }
+
+    const hash = avatarHashForUid(uid);
+    const bucket = hash.slice(0, 2);
+    const scopeDir = this.scopeDir(scope);
+
+    let hasBig = false;
+    let hasSmall = false;
+    let bigBytes = 0;
+    let smallBytes = 0;
+    if (scopeDir) {
+      const [big, small] = await Promise.all([
+        statSafe(join(scopeDir, bucket, `b_${hash}`)),
+        statSafe(join(scopeDir, bucket, `s_${hash}`)),
+      ]);
+      if (big) {
+        hasBig = true;
+        bigBytes = big.size;
+      }
+      if (small) {
+        hasSmall = true;
+        smallBytes = small.size;
+      }
+    }
+
+    return {
+      scope,
+      qq,
+      uid,
+      nick,
+      resolved: true,
+      hash,
+      bucket,
+      bigRel: `avatar/${scope}/${bucket}/b_${hash}`,
+      smallRel: `avatar/${scope}/${bucket}/s_${hash}`,
+      hasBig,
+      hasSmall,
+      bigBytes,
+      smallBytes,
+    };
+  }
+
   // ── internals ──────────────────────────────────────────────────────────────
 
   /** Bucket dir names (`00`…`ff`, `temp`, …) under a scope, or null if absent. */
@@ -316,4 +479,14 @@ function parseCursor(cursor: string | null): { bucketIndex: number; entryIndex: 
 function clampInt(n: number, lo: number, hi: number): number {
   const x = Math.floor(Number.isFinite(n) ? n : lo);
   return Math.min(hi, Math.max(lo, x));
+}
+
+/** stat that swallows ENOENT (and any error), returning null when absent. */
+async function statSafe(path: string): Promise<{ size: number } | null> {
+  try {
+    const st = await stat(path);
+    return st.isFile() ? { size: st.size } : null;
+  } catch {
+    return null;
+  }
 }

--- a/packages/service/src/account/export/contacts_export.ts
+++ b/packages/service/src/account/export/contacts_export.ts
@@ -1,0 +1,413 @@
+/**
+ * 联系人导出器 —— 导出**好友列表**或**某群的成员列表**为 csv / xlsx / json / txt
+ * （好友额外支持 vcard 电子名片）。
+ *
+ * 与消息导出流水线无关：数据来自本地资料库（`buddy_list` / `category_list_v2` /
+ * `profile_info_v6` / `group_member3`），一次性拉全后写盘。拉取能力由 deps 注入
+ * （service 包不依赖账号服务，照 chatlab / qzone deps 的模式；bigint 在注入侧已
+ * 归一化为字符串）。
+ *
+ * 头像不在这里下载：导出时把出现过的 uin 收进 `collectUins`，由 task_manager 的
+ * 「下载头像」阶段复用 {@link import('./avatar_export').exportAvatars} 统一处理，
+ * 和消息导出的头像阶段同构（带独立进度条）。
+ */
+
+import ExcelJS from 'exceljs';
+import { once } from 'node:events';
+import { createWriteStream } from 'node:fs';
+
+/** 注入的联系人数据拉取能力（bigint 已归一化为字符串）。 */
+export interface ContactsExportDeps {
+  /** 分页拉好友（`buddy_list`）。 */
+  listBuddies: (
+    limit: number,
+    offset: number,
+  ) => Promise<Array<{ uid: string; uin: string; qid: string; categoryId: number }>>;
+  /** 好友分组（`category_list_v2`）：id → 名称。 */
+  listCategories: () => Promise<Array<{ id: number; name: string }>>;
+  /** 批量取已缓存资料（`profile_info_v6`）；未缓存的好友不会返回。 */
+  profilesByUids: (uids: string[]) => Promise<
+    Array<{
+      uid: string;
+      nick: string;
+      remark: string;
+      signature: string;
+      gender: number;
+      age: number;
+      birthYear: number;
+      birthMonth: number;
+      birthDay: number;
+      intimacy: number;
+    }>
+  >;
+  /** 分页拉某群成员（`group_member3`）。 */
+  listGroupMembers: (
+    groupCode: string,
+    limit: number,
+    offset: number,
+  ) => Promise<
+    Array<{
+      uid: string;
+      uin: string;
+      card: string;
+      nick: string;
+      adminFlag: number;
+      customTitle: string;
+      memberLevel: number;
+      joinTime: number;
+      lastSpeakTime: number;
+    }>
+  >;
+  /** 群主 uid（用于把角色标成「群主」）；查不到回 null。 */
+  groupOwnerUid: (groupCode: string) => Promise<string | null>;
+}
+
+/** 联系人导出格式。 */
+export type ContactsFormat = 'json' | 'csv' | 'xlsx' | 'txt' | 'vcard';
+
+export interface ContactsExportResult {
+  filePath: string;
+  /** 写入的联系人条数。 */
+  count: number;
+}
+
+const BUDDY_PAGE = 1000;
+const MEMBER_PAGE = 1000;
+const PROFILE_CHUNK = 500;
+/** 翻页安全上限，防跑飞。 */
+const MAX_PAGES = 200;
+
+type Cell = string | number;
+
+/** 一列的定义：json 键 + 中文表头 + 取值函数。 */
+interface Col<T> {
+  key: string;
+  header: string;
+  get: (row: T) => Cell;
+}
+
+// ---- 通用小工具 ----
+
+/** 性别码 → 文字。 */
+function genderText(g: number): string {
+  return g === 1 ? '男' : g === 2 ? '女' : '';
+}
+
+/** 生日三段 → `YYYY-MM-DD`（缺失留空）。 */
+function birthdayText(y: number, m: number, d: number): string {
+  if (!y && !m && !d) return '';
+  const p = (n: number): string => n.toString().padStart(2, '0');
+  return `${y || 0}-${p(m || 0)}-${p(d || 0)}`;
+}
+
+/** 秒级时间戳 → `YYYY-MM-DD HH:mm`（0/空留空）。 */
+function timeText(sec: number): string {
+  if (!sec) return '';
+  const date = new Date(sec * 1000);
+  const p = (n: number): string => n.toString().padStart(2, '0');
+  return `${date.getFullYear()}-${p(date.getMonth() + 1)}-${p(date.getDate())} ${p(date.getHours())}:${p(date.getMinutes())}`;
+}
+
+/** CSV 字段转义：含逗号/引号/换行时加引号，内部引号翻倍。 */
+function escapeCsv(value: string): string {
+  return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+/** 一次性把内容写到文件（联系人量级不大）。 */
+async function writeFileStream(outputPath: string, body: string): Promise<void> {
+  const stream = createWriteStream(outputPath, { encoding: 'utf-8' });
+  if (!stream.write(body)) await once(stream, 'drain');
+  stream.end();
+  await once(stream, 'finish');
+}
+
+// ---- 各格式写盘 ----
+
+/** json：对象数组（英文键，便于程序消费）。 */
+async function writeJson<T>(cols: Array<Col<T>>, rows: T[], outputPath: string): Promise<void> {
+  const objects = rows.map((r) => Object.fromEntries(cols.map((c) => [c.key, c.get(r)])));
+  await writeFileStream(outputPath, JSON.stringify(objects, null, 2));
+}
+
+/** csv：UTF-8 BOM + 表头 + 数据行（CRLF，Excel 直开不乱码）。 */
+async function writeCsv<T>(cols: Array<Col<T>>, rows: T[], outputPath: string): Promise<void> {
+  const lines = [`﻿${cols.map((c) => escapeCsv(c.header)).join(',')}`];
+  for (const r of rows) {
+    lines.push(cols.map((c) => escapeCsv(String(c.get(r)))).join(','));
+  }
+  await writeFileStream(outputPath, lines.join('\r\n') + '\r\n');
+}
+
+/** txt：每个联系人一段「表头: 值」+ 分隔线。 */
+async function writeTxt<T>(cols: Array<Col<T>>, rows: T[], outputPath: string): Promise<void> {
+  const blocks = rows.map((r) => {
+    const body = cols
+      .map((c) => `${c.header}: ${String(c.get(r))}`)
+      .join('\n');
+    return `${body}\n${'—'.repeat(24)}`;
+  });
+  await writeFileStream(outputPath, blocks.join('\n') + '\n');
+}
+
+/** xlsx：ExcelJS 流式写一张表（表头 + 每联系人一行）。 */
+async function writeXlsx<T>(
+  cols: Array<Col<T>>,
+  rows: T[],
+  outputPath: string,
+  sheetName: string,
+): Promise<void> {
+  const workbook = new ExcelJS.stream.xlsx.WorkbookWriter({
+    filename: outputPath,
+    useStyles: false,
+    useSharedStrings: false,
+  });
+  const sheet = workbook.addWorksheet(sheetName);
+  sheet.addRow(cols.map((c) => c.header)).commit();
+  for (const r of rows) {
+    sheet.addRow(cols.map((c) => c.get(r))).commit();
+  }
+  sheet.commit();
+  await workbook.commit();
+}
+
+/** 按格式分派（vcard 由调用方单独处理）。 */
+async function writeTable<T>(
+  format: Exclude<ContactsFormat, 'vcard'>,
+  cols: Array<Col<T>>,
+  rows: T[],
+  outputPath: string,
+  sheetName: string,
+): Promise<void> {
+  switch (format) {
+    case 'json':
+      return writeJson(cols, rows, outputPath);
+    case 'csv':
+      return writeCsv(cols, rows, outputPath);
+    case 'xlsx':
+      return writeXlsx(cols, rows, outputPath, sheetName);
+    default:
+      return writeTxt(cols, rows, outputPath);
+  }
+}
+
+/** vCard 3.0 文本转义（反斜杠/逗号/分号/换行）。 */
+function escapeVcard(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/,/g, '\\,')
+    .replace(/;/g, '\\;');
+}
+
+// ---- 好友导出 ----
+
+interface FriendRow {
+  uin: string;
+  nick: string;
+  remark: string;
+  category: string;
+  signature: string;
+  gender: number;
+  age: number;
+  birthYear: number;
+  birthMonth: number;
+  birthDay: number;
+  intimacy: number;
+  uid: string;
+}
+
+const FRIEND_COLS: Array<Col<FriendRow>> = [
+  { key: 'uin', header: 'QQ号', get: (r) => r.uin },
+  { key: 'nick', header: '昵称', get: (r) => r.nick },
+  { key: 'remark', header: '备注', get: (r) => r.remark },
+  { key: 'category', header: '分组', get: (r) => r.category },
+  { key: 'signature', header: '签名', get: (r) => r.signature },
+  { key: 'gender', header: '性别', get: (r) => genderText(r.gender) },
+  { key: 'age', header: '年龄', get: (r) => (r.age > 0 ? r.age : '') },
+  { key: 'birthday', header: '生日', get: (r) => birthdayText(r.birthYear, r.birthMonth, r.birthDay) },
+  { key: 'intimacy', header: '亲密度', get: (r) => (r.intimacy > 0 ? r.intimacy : '') },
+  { key: 'uid', header: 'uid', get: (r) => r.uid },
+];
+
+export interface ExportFriendsOpts {
+  format: ContactsFormat;
+  outputPath: string;
+  /** 只导出这些分组 id（空 / 省略 = 全部好友）。 */
+  categoryIds?: number[];
+  /** 出现过的好友 uin（供头像阶段下载），传入则填充。 */
+  collectUins?: Set<string>;
+  onProgress?: (current: number, total: number, note: string) => void;
+  signal?: AbortSignal;
+}
+
+/** 拉全好友列表（翻页）。 */
+async function fetchAllBuddies(
+  deps: ContactsExportDeps,
+  signal?: AbortSignal,
+): Promise<Array<{ uid: string; uin: string; qid: string; categoryId: number }>> {
+  const all: Array<{ uid: string; uin: string; qid: string; categoryId: number }> = [];
+  for (let page = 0; page < MAX_PAGES; page++) {
+    if (signal?.aborted) break;
+    const batch = await deps.listBuddies(BUDDY_PAGE, page * BUDDY_PAGE);
+    all.push(...batch);
+    if (batch.length < BUDDY_PAGE) break;
+  }
+  return all;
+}
+
+/** 导出好友列表。 */
+export async function exportFriends(
+  opts: ExportFriendsOpts,
+  deps: ContactsExportDeps,
+): Promise<ContactsExportResult> {
+  opts.onProgress?.(0, 0, '拉取好友…');
+  let buddies = await fetchAllBuddies(deps, opts.signal);
+  if (opts.categoryIds && opts.categoryIds.length > 0) {
+    const wanted = new Set(opts.categoryIds);
+    buddies = buddies.filter((b) => wanted.has(b.categoryId));
+  }
+
+  const categories = await deps.listCategories();
+  const categoryName = new Map(categories.map((c) => [c.id, c.name]));
+
+  // 批量补资料（未缓存的以空值兜底）。
+  const profileByUid = new Map<
+    string,
+    Awaited<ReturnType<ContactsExportDeps['profilesByUids']>>[number]
+  >();
+  const uids = buddies.map((b) => b.uid);
+  for (let i = 0; i < uids.length; i += PROFILE_CHUNK) {
+    if (opts.signal?.aborted) break;
+    const chunk = uids.slice(i, i + PROFILE_CHUNK);
+    const profiles = await deps.profilesByUids(chunk);
+    for (const p of profiles) profileByUid.set(p.uid, p);
+    opts.onProgress?.(Math.min(i + chunk.length, uids.length), uids.length, '补全资料…');
+  }
+
+  const rows: FriendRow[] = buddies.map((b) => {
+    const p = profileByUid.get(b.uid);
+    opts.collectUins?.add(b.uin);
+    return {
+      uin: b.uin,
+      nick: p?.nick ?? '',
+      remark: p?.remark ?? '',
+      category: categoryName.get(b.categoryId) ?? (b.categoryId ? `分组${b.categoryId}` : '我的好友'),
+      signature: p?.signature ?? '',
+      gender: p?.gender ?? 0,
+      age: p?.age ?? 0,
+      birthYear: p?.birthYear ?? 0,
+      birthMonth: p?.birthMonth ?? 0,
+      birthDay: p?.birthDay ?? 0,
+      intimacy: p?.intimacy ?? 0,
+      uid: b.uid,
+    };
+  });
+
+  opts.onProgress?.(rows.length, rows.length, `${rows.length} 位好友`);
+
+  if (opts.format === 'vcard') {
+    await writeFriendsVcard(rows, opts.outputPath);
+  } else {
+    await writeTable(opts.format, FRIEND_COLS, rows, opts.outputPath, '好友');
+  }
+  return { filePath: opts.outputPath, count: rows.length };
+}
+
+/** 好友 → vCard 3.0（一人一张名片）。 */
+async function writeFriendsVcard(rows: FriendRow[], outputPath: string): Promise<void> {
+  const cards = rows.map((r) => {
+    const display = r.remark || r.nick || r.uin;
+    const noteParts = [
+      r.remark ? `备注: ${r.remark}` : '',
+      r.category ? `分组: ${r.category}` : '',
+      r.signature ? `签名: ${r.signature}` : '',
+      `QQ: ${r.uin}`,
+    ].filter(Boolean);
+    const lines = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      `FN:${escapeVcard(display)}`,
+      `N:${escapeVcard(r.nick || display)};;;;`,
+      r.nick ? `NICKNAME:${escapeVcard(r.nick)}` : '',
+      `NOTE:${escapeVcard(noteParts.join('\n'))}`,
+      `X-QQ:${escapeVcard(r.uin)}`,
+      r.gender ? `GENDER:${r.gender === 1 ? 'M' : 'F'}` : '',
+      'END:VCARD',
+    ].filter(Boolean);
+    return lines.join('\r\n');
+  });
+  await writeFileStream(outputPath, cards.join('\r\n') + '\r\n');
+}
+
+// ---- 群成员导出 ----
+
+interface MemberRow {
+  uin: string;
+  card: string;
+  nick: string;
+  role: string;
+  customTitle: string;
+  memberLevel: number;
+  joinTime: number;
+  lastSpeakTime: number;
+  uid: string;
+}
+
+const MEMBER_COLS: Array<Col<MemberRow>> = [
+  { key: 'uin', header: 'QQ号', get: (r) => r.uin },
+  { key: 'card', header: '群名片', get: (r) => r.card },
+  { key: 'nick', header: '昵称', get: (r) => r.nick },
+  { key: 'role', header: '角色', get: (r) => r.role },
+  { key: 'title', header: '头衔', get: (r) => r.customTitle },
+  { key: 'level', header: '群等级', get: (r) => (r.memberLevel > 0 ? r.memberLevel : '') },
+  { key: 'joinTime', header: '入群时间', get: (r) => timeText(r.joinTime) },
+  { key: 'lastSpeakTime', header: '最后发言', get: (r) => timeText(r.lastSpeakTime) },
+  { key: 'uid', header: 'uid', get: (r) => r.uid },
+];
+
+export interface ExportGroupMembersOpts {
+  groupCode: string;
+  format: Exclude<ContactsFormat, 'vcard'>;
+  outputPath: string;
+  collectUins?: Set<string>;
+  onProgress?: (current: number, total: number, note: string) => void;
+  signal?: AbortSignal;
+}
+
+/** 导出某群的成员列表。 */
+export async function exportGroupMembers(
+  opts: ExportGroupMembersOpts,
+  deps: ContactsExportDeps,
+): Promise<ContactsExportResult> {
+  opts.onProgress?.(0, 0, '拉取群成员…');
+  const members: Awaited<ReturnType<ContactsExportDeps['listGroupMembers']>> = [];
+  for (let page = 0; page < MAX_PAGES; page++) {
+    if (opts.signal?.aborted) break;
+    const batch = await deps.listGroupMembers(opts.groupCode, MEMBER_PAGE, page * MEMBER_PAGE);
+    members.push(...batch);
+    opts.onProgress?.(members.length, members.length, `已获取 ${members.length} 位`);
+    if (batch.length < MEMBER_PAGE) break;
+  }
+
+  const ownerUid = await deps.groupOwnerUid(opts.groupCode).catch(() => null);
+
+  const rows: MemberRow[] = members.map((m) => {
+    opts.collectUins?.add(m.uin);
+    const role = m.uid && m.uid === ownerUid ? '群主' : m.adminFlag ? '管理员' : '成员';
+    return {
+      uin: m.uin,
+      card: m.card,
+      nick: m.nick,
+      role,
+      customTitle: m.customTitle,
+      memberLevel: m.memberLevel,
+      joinTime: m.joinTime,
+      lastSpeakTime: m.lastSpeakTime,
+      uid: m.uid,
+    };
+  });
+
+  opts.onProgress?.(rows.length, rows.length, `${rows.length} 位成员`);
+  await writeTable(opts.format, MEMBER_COLS, rows, opts.outputPath, '群成员');
+  return { filePath: opts.outputPath, count: rows.length };
+}

--- a/packages/service/src/account/export/index.ts
+++ b/packages/service/src/account/export/index.ts
@@ -31,6 +31,15 @@ export {
   type QzoneExportResult,
 } from './qzone_export';
 export {
+  exportFriends,
+  exportGroupMembers,
+  type ContactsExportDeps,
+  type ContactsFormat,
+  type ContactsExportResult,
+  type ExportFriendsOpts,
+  type ExportGroupMembersOpts,
+} from './contacts_export';
+export {
   avatarUrlForUin,
   iterateConv,
   resolveGroupSenders,

--- a/packages/service/src/account/export/message_source.ts
+++ b/packages/service/src/account/export/message_source.ts
@@ -12,6 +12,17 @@
  * the `(40027,40003)` composite index and the output is naturally oldest-first
  * (the order a chat log reads top-to-bottom). The cursor advances to the last
  * seq of each page; we stop when a short page comes back.
+ *
+ * Mixed-seq conversations: phone→PC migrated history lands with no per-conv seq
+ * (40003 = 0/NULL), so the seq cursor (`40003 > 0`) never returns it — yet the
+ * PC's own messages (seq > 0) do, so a naive seq scan silently drops all the
+ * imported history. To capture both, we run TWO cursors and merge them by
+ * sendTime: the seq scan (seq > 0) and a rowid scan restricted to seq-less rows
+ * (the imported block). Each stream is ~oldest-first on its own; the merge
+ * interleaves them into one globally chronological stream. When a conversation
+ * has no imported rows the seq-less stream is empty (one cheap query), and when
+ * every row is seq-less the seq stream is empty — both degenerate cases fall out
+ * of the same merge with no special-casing.
  */
 
 import type { MsgService, RenderGroupMsg, RenderC2cMsg } from '../msg';
@@ -40,9 +51,36 @@ function withinRange(sendTimeSec: number, range?: ExportTimeRange): boolean {
 }
 
 /**
+ * Merge two ~oldest-first message streams into one, ordered by sendTime. Both
+ * inputs are individually near-ascending on sendTime (a seq scan and a rowid
+ * scan of an imported block), so a classic two-way merge yields a globally
+ * chronological stream while only ever holding one message from each in memory.
+ * Ties and small local disorder inside a stream are preserved as-is — that's
+ * the best obtainable order without a usable seq on the imported rows.
+ */
+async function* mergeBySendTime<T extends { sendTime: bigint }>(
+  a: AsyncGenerator<T>,
+  b: AsyncGenerator<T>,
+): AsyncGenerator<T> {
+  let na = await a.next();
+  let nb = await b.next();
+  while (!na.done && !nb.done) {
+    if (na.value.sendTime <= nb.value.sendTime) {
+      yield na.value;
+      na = await a.next();
+    } else {
+      yield nb.value;
+      nb = await b.next();
+    }
+  }
+  for (; !na.done; na = await a.next()) yield na.value;
+  for (; !nb.done; nb = await b.next()) yield nb.value;
+}
+
+/**
  * Yield every message of a group, oldest-first, paging under the hood.
  *
- * NOTE: the cursor uses `msgSeq > lastSeq`, which assumes per-group seqs are
+ * NOTE: the seq cursor uses `msgSeq > lastSeq`, which assumes per-group seqs are
  * unique (they are — 40003 is a per-group incrementing sequence). If a future
  * dataset proves otherwise, switch the cursor to a (seq,msgId) tuple.
  */
@@ -52,47 +90,43 @@ export async function* iterateGroupMessages(
   opts: IterateOptions = {},
 ): AsyncGenerator<RenderGroupMsg> {
   const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE;
-  let cursor = 0n;
-  let sawSeqRows = false;
-  for (;;) {
-    const page = await msgs.getGroupAfter(groupCode, cursor, pageSize);
-    if (page.length === 0) break;
-    sawSeqRows = true;
-    for (const m of page) {
-      if (withinRange(Number(m.sendTime), opts.range)) yield m;
-    }
-    const last = page[page.length - 1]!;
-    cursor = last.msgSeq;
-    // A short page means we reached the tail — no need for one more empty query.
-    if (page.length < pageSize) break;
-  }
-  // Fallback: the seq cursor matched no rows at all, yet the conversation has
-  // messages (they COUNT and render in the chat view). This is the degenerate
-  // msgSeq case — every 40003 is 0/NULL, typically migration-imported history.
-  // Re-scan by rowid so those messages still export. See iterateByRowId.
-  if (!sawSeqRows) {
-    yield* iterateGroupByRowId(msgs, groupCode, opts);
+  const merged = mergeBySendTime(
+    pageGroupBySeq(msgs, groupCode, pageSize),
+    pageGroupBySeqlessRowId(msgs, groupCode, pageSize),
+  );
+  for await (const m of merged) {
+    if (withinRange(Number(m.sendTime), opts.range)) yield m;
   }
 }
 
-/**
- * Fallback scan for {@link iterateGroupMessages}: page by rowid (insertion
- * order) instead of msgSeq. Only an approximation of send-time order, so this
- * runs strictly as a last resort when msgSeq is unusable.
- */
-async function* iterateGroupByRowId(
+/** Group seq cursor (`40003 > lastSeq`): all messages that carry a real seq. */
+async function* pageGroupBySeq(
   msgs: MsgService,
   groupCode: string,
-  opts: IterateOptions,
+  pageSize: number,
 ): AsyncGenerator<RenderGroupMsg> {
-  const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE;
   let cursor = 0n;
   for (;;) {
-    const page = await msgs.getGroupAfterRowId(groupCode, cursor, pageSize);
+    const page = await msgs.getGroupAfter(groupCode, cursor, pageSize);
     if (page.length === 0) break;
-    for (const m of page) {
-      if (withinRange(Number(m.sendTime), opts.range)) yield m;
-    }
+    for (const m of page) yield m;
+    cursor = page[page.length - 1]!.msgSeq;
+    // A short page means we reached the tail — no need for one more empty query.
+    if (page.length < pageSize) break;
+  }
+}
+
+/** Group rowid cursor over seq-less rows only: the migration-imported block. */
+async function* pageGroupBySeqlessRowId(
+  msgs: MsgService,
+  groupCode: string,
+  pageSize: number,
+): AsyncGenerator<RenderGroupMsg> {
+  let cursor = 0n;
+  for (;;) {
+    const page = await msgs.getGroupSeqlessAfterRowId(groupCode, cursor, pageSize);
+    if (page.length === 0) break;
+    for (const m of page) yield m;
     cursor = page[page.length - 1]!.rowId;
     if (page.length < pageSize) break;
   }
@@ -107,44 +141,42 @@ export async function* iterateC2cMessages(
   opts: IterateOptions = {},
 ): AsyncGenerator<RenderC2cMsg> {
   const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE;
-  let cursor = 0n;
-  let sawSeqRows = false;
-  for (;;) {
-    const page = await msgs.getC2cAfter(peerUid, cursor, pageSize);
-    if (page.length === 0) break;
-    sawSeqRows = true;
-    for (const m of page) {
-      if (withinRange(Number(m.sendTime), opts.range)) yield m;
-    }
-    const last = page[page.length - 1]!;
-    cursor = last.msgSeq;
-    if (page.length < pageSize) break;
-  }
-  // Fallback for degenerate msgSeq (all 0/NULL — migration-imported history):
-  // the seq cursor matched nothing though the conversation has messages, so
-  // re-scan by rowid. See iterateC2cByRowId.
-  if (!sawSeqRows) {
-    yield* iterateC2cByRowId(msgs, peerUid, opts);
+  const merged = mergeBySendTime(
+    pageC2cBySeq(msgs, peerUid, pageSize),
+    pageC2cBySeqlessRowId(msgs, peerUid, pageSize),
+  );
+  for await (const m of merged) {
+    if (withinRange(Number(m.sendTime), opts.range)) yield m;
   }
 }
 
-/**
- * Fallback scan for {@link iterateC2cMessages}: page by rowid (insertion order)
- * instead of msgSeq. Approximate ordering — last-resort only.
- */
-async function* iterateC2cByRowId(
+/** C2c seq cursor (`40003 > lastSeq`): all messages that carry a real seq. */
+async function* pageC2cBySeq(
   msgs: MsgService,
   peerUid: string,
-  opts: IterateOptions,
+  pageSize: number,
 ): AsyncGenerator<RenderC2cMsg> {
-  const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE;
   let cursor = 0n;
   for (;;) {
-    const page = await msgs.getC2cAfterRowId(peerUid, cursor, pageSize);
+    const page = await msgs.getC2cAfter(peerUid, cursor, pageSize);
     if (page.length === 0) break;
-    for (const m of page) {
-      if (withinRange(Number(m.sendTime), opts.range)) yield m;
-    }
+    for (const m of page) yield m;
+    cursor = page[page.length - 1]!.msgSeq;
+    if (page.length < pageSize) break;
+  }
+}
+
+/** C2c rowid cursor over seq-less rows only: the migration-imported block. */
+async function* pageC2cBySeqlessRowId(
+  msgs: MsgService,
+  peerUid: string,
+  pageSize: number,
+): AsyncGenerator<RenderC2cMsg> {
+  let cursor = 0n;
+  for (;;) {
+    const page = await msgs.getC2cSeqlessAfterRowId(peerUid, cursor, pageSize);
+    if (page.length === 0) break;
+    for (const m of page) yield m;
     cursor = page[page.length - 1]!.rowId;
     if (page.length < pageSize) break;
   }

--- a/packages/service/src/account/export/task_manager.ts
+++ b/packages/service/src/account/export/task_manager.ts
@@ -22,6 +22,12 @@ import { exportToXlsx } from './xlsx_exporter';
 import { exportToChatlab, type ChatlabDeps } from './chatlab_exporter';
 import { exportToHtml } from './html_exporter';
 import { exportQzone, type QzoneExportDeps } from './qzone_export';
+import {
+  exportFriends,
+  exportGroupMembers,
+  type ContactsExportDeps,
+  type ContactsFormat,
+} from './contacts_export';
 import { exportAvatars } from './avatar_export';
 import {
   copyFoundMedia,
@@ -94,6 +100,9 @@ export interface ExportTask {
   chatlab?: boolean;
   /** 好友 QQ 空间说说导出（`conv` = 好友 uin；走独立的 Web 拉取流水线）。 */
   qzone?: boolean;
+  /** 联系人导出（好友列表 / 群成员列表；走独立的资料库拉取流水线）。
+   *  `group` 时 `conv` = 群号；`friends` 时 `conv` 为空。 */
+  contacts?: { scope: 'friends' | 'group'; categoryIds?: number[] };
   /** Media export options, when 导出媒体 is on. */
   media?: MediaExportOptions;
   /** Inclusive send-time window for this export, if narrowed from 全部时间. */
@@ -132,6 +141,8 @@ export interface MediaDeps {
   chatlab?: ChatlabDeps;
   /** QQ 空间说说拉取能力（Web CGI；需在线 QQ，由 app 注入）。 */
   qzone?: QzoneExportDeps;
+  /** 联系人（好友 / 群成员）资料库拉取能力（由 app 注入）。 */
+  contacts?: ContactsExportDeps;
 }
 
 export class ExportTaskManager extends EventEmitter {
@@ -201,6 +212,8 @@ export class ExportTaskManager extends EventEmitter {
     chatlab?: boolean;
     /** 好友 QQ 空间说说导出（走独立流水线）。 */
     qzone?: boolean;
+    /** 联系人导出（好友 / 群成员；走独立流水线）。 */
+    contacts?: { scope: 'friends' | 'group'; categoryIds?: number[] };
     media?: MediaExportOptions;
     range?: ExportTimeRange;
   }): Promise<string> {
@@ -208,6 +221,34 @@ export class ExportTaskManager extends EventEmitter {
     const wantMedia = Boolean(opts.media?.exportMedia);
     const wantAvatars = Boolean(opts.exportAvatar);
     const wantTranscribe = Boolean(opts.media?.transcribeVoice);
+
+    // 联系人导出（好友 / 群成员）是独立流水线（写表 + 可选头像），不复用消息流水线。
+    if (opts.contacts) {
+      const cStages: TaskStage[] = [
+        { key: 'message', label: '导出联系人', status: 'pending', current: 0, total: opts.total },
+      ];
+      if (wantAvatars) cStages.push({ key: 'avatar', label: '下载头像', status: 'pending', current: 0, total: 0 });
+      const cTask: ExportTask = {
+        id,
+        kind: opts.kind,
+        conv: opts.conv,
+        name: opts.name,
+        format: opts.format,
+        status: 'pending',
+        progress: 0,
+        current: 0,
+        total: opts.total,
+        contacts: opts.contacts,
+        exportAvatar: wantAvatars,
+        stages: cStages,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      this.tasks.set(id, cTask);
+      this.saveTasks();
+      void this.runContactsTask(id);
+      return id;
+    }
 
     // 好友空间导出是独立的两段式流水线（说说 + 可选配图），不复用消息流水线。
     if (opts.qzone) {
@@ -574,6 +615,118 @@ export class ExportTaskManager extends EventEmitter {
           { persist: true },
         );
       }
+      task.status = 'completed';
+      task.progress = 100;
+    } catch (e: any) {
+      task.status = 'failed';
+      task.error = String(e?.message ?? e);
+      const running = task.stages.find((s) => s.status === 'running');
+      if (running) { running.status = 'failed'; running.note = task.error; }
+    } finally {
+      task.updatedAt = Date.now();
+      this.abortControllers.delete(id);
+      this.saveTasks();
+      this.emit('progress', {
+        taskId: id,
+        status: task.status,
+        progress: task.progress,
+        current: task.current,
+        message: task.status === 'completed' ? '导出完成' : task.error ?? '已取消',
+      });
+    }
+  }
+
+  /**
+   * 联系人导出：拉好友/群成员写表 →（可选）下载头像。独立于消息流水线；
+   * `contacts.scope==='group'` 时 `conv` 为群号，拉取能力走注入的 `deps.contacts`。
+   */
+  private async runContactsTask(id: string): Promise<void> {
+    const task = this.tasks.get(id);
+    if (!task || task.status === 'cancelled') return;
+
+    task.status = 'running';
+    task.updatedAt = Date.now();
+    this.saveTasks();
+
+    const abort = new AbortController();
+    this.abortControllers.set(id, abort);
+    const aborted = (): boolean => abort.signal.aborted;
+
+    try {
+      const deps = this.deps.contacts;
+      if (!deps) throw new Error('联系人数据拉取能力不可用。');
+      const avatarCache = this.deps.avatarCache;
+      const wantAvatars = Boolean(task.exportAvatar && avatarCache);
+
+      // 有头像 → 产物为 bundle 目录（表文件 + avatars/），否则单文件。
+      const isBundle = wantAvatars;
+      const outDir = isBundle ? join(this.cacheDir, `bundle-${id}`) : this.cacheDir;
+      if (isBundle) mkdirSync(outDir, { recursive: true });
+      const ext = task.format === 'vcard' ? 'vcf' : task.format;
+      const outPath = join(outDir, `${task.name}.${ext}`);
+      const uins = wantAvatars ? new Set<string>() : undefined;
+
+      if (task.exportAvatar && !avatarCache) {
+        const s = this.stage(task, 'avatar');
+        if (s) { s.status = 'skipped'; s.note = '头像服务不可用'; }
+      }
+
+      // ---- stage: 导出联系人 ----
+      this.touchStage(task, 'message', { status: 'running', note: '开始导出' }, { persist: true });
+      const onProgress = (current: number, total: number, note: string): void => {
+        if (aborted()) return;
+        this.touchStage(task, 'message', { current, total, note });
+      };
+      const result =
+        task.contacts?.scope === 'group'
+          ? await exportGroupMembers(
+              {
+                groupCode: task.conv,
+                format: (task.format === 'vcard' ? 'txt' : task.format) as Exclude<ContactsFormat, 'vcard'>,
+                outputPath: outPath,
+                collectUins: uins,
+                onProgress,
+                signal: abort.signal,
+              },
+              deps,
+            )
+          : await exportFriends(
+              {
+                format: task.format as ContactsFormat,
+                outputPath: outPath,
+                categoryIds: task.contacts?.categoryIds,
+                collectUins: uins,
+                onProgress,
+                signal: abort.signal,
+              },
+              deps,
+            );
+      if (aborted()) { task.status = 'cancelled'; return; }
+
+      task.filePath = result.filePath;
+      task.current = result.count;
+      if (isBundle) task.bundleDir = outDir;
+      this.touchStage(
+        task,
+        'message',
+        { status: 'completed', current: result.count, total: result.count, note: `${result.count} 位联系人` },
+        { persist: true },
+      );
+
+      // ---- stage: 下载头像（可选） ----
+      if (wantAvatars && uins && avatarCache) {
+        this.touchStage(task, 'avatar', { status: 'running', total: uins.size, current: 0, note: `下载 0/${uins.size}` }, { persist: true });
+        const r = await exportAvatars(avatarCache, uins, outDir, {
+          onProgress: (done, total) => {
+            if (aborted()) return;
+            this.touchStage(task, 'avatar', { current: done, total, note: `下载 ${done}/${total}` });
+          },
+        });
+        task.avatarCount = r.ok;
+        this.touchStage(task, 'avatar', { status: 'completed', current: r.total, total: r.total, failed: r.failed, note: `已下载 ${r.ok}${r.failed ? ` · 失败 ${r.failed}` : ''}` }, { persist: true });
+      }
+      if (aborted()) { task.status = 'cancelled'; return; }
+
       task.status = 'completed';
       task.progress = 100;
     } catch (e: any) {

--- a/packages/service/src/account/export/types.ts
+++ b/packages/service/src/account/export/types.ts
@@ -14,8 +14,8 @@
 
 import type { RenderElement } from '../msg_view';
 
-/** Output formats, mirroring QCE (+ jsonl). html lands in a later step. */
-export type ExportFormat = 'json' | 'jsonl' | 'txt' | 'csv' | 'xlsx' | 'html';
+/** Output formats, mirroring QCE (+ jsonl). `vcard` is contacts-only (联系人导出). */
+export type ExportFormat = 'json' | 'jsonl' | 'txt' | 'csv' | 'xlsx' | 'html' | 'vcard';
 
 /** Conversation kind an export targets. */
 export type ConvKind = 'group' | 'c2c';

--- a/packages/service/src/account/msg.ts
+++ b/packages/service/src/account/msg.ts
@@ -33,6 +33,22 @@ import { toRenderElements, type RenderElement } from './msg_view';
 const bodyCodec = new ProtoMsg(MsgBody);
 
 /**
+ * Reversible soft-delete markers (see {@link MsgService.deleteMessage}).
+ *
+ * `SOFT_DELETE_MASK` is XOR-ed into the numeric partition key 40027 (real group
+ * code / private-chat sortNo). Bit 62 sits far above any real group code or peer
+ * index, so toggling it moves the row out of every real conversation query and
+ * never collides; XOR-ing again restores the original value.
+ *
+ * `SOFT_DELETE_UID_PREFIX` is prepended to the TEXT key 40021 on the c2c/dataline
+ * tables to also cover the uid-fallback and device-line query paths (which filter
+ * on 40021, not 40027). Restore only strips it from rows that still carry the
+ * mask bit, so it can never corrupt a live uid (real uids start with `u_`).
+ */
+const SOFT_DELETE_MASK = 1n << 62n;
+const SOFT_DELETE_UID_PREFIX = 'weqdel';
+
+/**
  * ElementType values that render as a media thumbnail in a reply quote. A reply
  * whose stored `origElements` lacks all of these (QQ NT stores only a "[图片]"
  * text placeholder in the 40800 body) is a candidate for 40900-cache enrichment.
@@ -178,7 +194,61 @@ export class MsgService {
     return affected > 0;
   }
 
-  // ---- c2c -----------------------------------------------------------------
+  /**
+   * Reversible soft-delete: hide a message from its conversation by XOR-ing a
+   * high-bit mask into the 40027 partition key (real group code / private-chat
+   * sortNo), plus prefixing the 40021 uid key on the c2c/dataline tables so the
+   * uid-fallback and device-line queries miss it too. The row stays in the DB;
+   * {@link restoreMessage} brings it back. Searches c2c → dataline → group and
+   * acts on whichever holds the row. Returns true if a row was hidden.
+   */
+  async deleteMessage(msgId: bigint): Promise<boolean> {
+    let n = await this.session.c2cMsgs.softDelete(msgId, SOFT_DELETE_MASK, SOFT_DELETE_UID_PREFIX);
+    if (n === 0) n = await this.session.datalineMsgs.softDelete(msgId, SOFT_DELETE_MASK, SOFT_DELETE_UID_PREFIX);
+    if (n === 0) n = await this.session.groupMsgs.softDeleteMsg(msgId, SOFT_DELETE_MASK);
+    return n > 0;
+  }
+
+  /**
+   * Reverse a {@link deleteMessage} soft-delete. Guarded so calling it on a
+   * message that was never soft-deleted is a harmless no-op (returns false).
+   */
+  async restoreMessage(msgId: bigint): Promise<boolean> {
+    let n = await this.session.c2cMsgs.restore(msgId, SOFT_DELETE_MASK, SOFT_DELETE_UID_PREFIX);
+    if (n === 0) n = await this.session.datalineMsgs.restore(msgId, SOFT_DELETE_MASK, SOFT_DELETE_UID_PREFIX);
+    if (n === 0) n = await this.session.groupMsgs.restoreMsg(msgId, SOFT_DELETE_MASK);
+    return n > 0;
+  }
+
+  /**
+   * Hard-delete: physically drop the message row by msgId. Unlike
+   * {@link deleteMessage} (the reversible soft-delete) this is IRREVERSIBLE —
+   * the row is gone and cannot be restored. Searches c2c → dataline → group and
+   * deletes from whichever holds the row. Returns true if a row was deleted.
+   */
+  async hardDeleteMessage(msgId: bigint): Promise<boolean> {
+    let n = await this.session.c2cMsgs.hardDelete(msgId);
+    if (n === 0) n = await this.session.datalineMsgs.hardDelete(msgId);
+    if (n === 0) n = await this.session.groupMsgs.hardDeleteMsg(msgId);
+    return n > 0;
+  }
+
+  /**
+   * List the soft-deleted messages of one conversation (see {@link deleteMessage}),
+   * newest-first, rendered exactly like a normal page so the UI can reuse its
+   * chat bubbles. Group rows are found at `groupCode ^ mask`; c2c/dataline rows
+   * by the `weqdel`-prefixed uid — the same table split as the live queries.
+   */
+  async getDeletedMessages(kind: 'c2c' | 'group', conv: string, limit = 200): Promise<RenderC2cMsg[] | RenderGroupMsg[]> {
+    if (kind === 'group') {
+      const msgs = await this.session.groupMsgs.listDeleted(conv, SOFT_DELETE_MASK, limit);
+      await this.enrichReplyMedia(msgs, 'group');
+      return msgs.map(renderGroup);
+    }
+    const msgs = await this.c2cDbFor(conv).listDeleted(conv, SOFT_DELETE_UID_PREFIX, limit);
+    await this.enrichReplyMedia(msgs, 'c2c');
+    return msgs.map(renderC2c);
+  }
 
   /** Newest N private-chat messages with one peer. */
   async getC2cLatest(targetUid: string, limit = 50): Promise<RenderC2cMsg[]> {

--- a/packages/service/src/account/msg.ts
+++ b/packages/service/src/account/msg.ts
@@ -19,16 +19,37 @@ import {
   ProtoMsg,
   encodeElement,
   Element,
+  ElementType,
   validateComposeMessage,
   COMPOSE_ELEMENT_SPECS,
   isDatalineUid,
   type ComposeKind,
   type FieldSpec,
+  type MsgCacheRecord,
 } from '@weq/codec';
 import { MsgBody } from '@weq/codec/proto/msg/40800';
 import { toRenderElements, type RenderElement } from './msg_view';
 
 const bodyCodec = new ProtoMsg(MsgBody);
+
+/**
+ * ElementType values that render as a media thumbnail in a reply quote. A reply
+ * whose stored `origElements` lacks all of these (QQ NT stores only a "[图片]"
+ * text placeholder in the 40800 body) is a candidate for 40900-cache enrichment.
+ */
+const REPLY_MEDIA_TYPES: ReadonlySet<number> = new Set([
+  ElementType.PIC,
+  ElementType.VIDEO,
+  ElementType.FILE,
+  ElementType.MFACE,
+  ElementType.PTT,
+]);
+
+/** A message carrying a reply element, tagged with its msgId for a 40900 lookup. */
+interface ReplyBearer {
+  msgId: bigint;
+  elements: Element[];
+}
 
 /**
  * Input for authoring a new message. `elements` is the *raw* authored array
@@ -162,24 +183,28 @@ export class MsgService {
   /** Newest N private-chat messages with one peer. */
   async getC2cLatest(targetUid: string, limit = 50): Promise<RenderC2cMsg[]> {
     const msgs = await this.c2cDbFor(targetUid).listLatest(this.c2cPartition(targetUid), limit);
+    await this.enrichReplyMedia(msgs, 'c2c');
     return msgs.map(renderC2c);
   }
 
   /** Private-chat page just older than `beforeSeq` (scroll-up). */
   async getC2cBefore(targetUid: string, beforeSeq: bigint, limit = 50): Promise<RenderC2cMsg[]> {
     const msgs = await this.c2cDbFor(targetUid).listBefore(this.c2cPartition(targetUid), beforeSeq, limit);
+    await this.enrichReplyMedia(msgs, 'c2c');
     return msgs.map(renderC2c);
   }
 
   /** Private-chat page just newer than `afterSeq` (scroll-down / jump context). */
   async getC2cAfter(targetUid: string, afterSeq: bigint, limit = 50): Promise<RenderC2cMsg[]> {
     const msgs = await this.c2cDbFor(targetUid).listAfter(this.c2cPartition(targetUid), afterSeq, limit);
+    await this.enrichReplyMedia(msgs, 'c2c');
     return msgs.map(renderC2c);
   }
 
   /** Re-read private-chat messages with seq >= `sinceSeq` (live refresh). */
   async getC2cFrom(targetUid: string, sinceSeq: bigint, limit = 500): Promise<RenderC2cMsg[]> {
     const msgs = await this.c2cDbFor(targetUid).listFrom(this.c2cPartition(targetUid), sinceSeq, limit);
+    await this.enrichReplyMedia(msgs, 'c2c');
     return msgs.map(renderC2c);
   }
 
@@ -198,24 +223,28 @@ export class MsgService {
   /** Newest N group messages in one group. */
   async getGroupLatest(targetGroupCode: string, limit = 50): Promise<RenderGroupMsg[]> {
     const msgs = await this.session.groupMsgs.listLatest(targetGroupCode, limit);
+    await this.enrichReplyMedia(msgs, 'group');
     return msgs.map(renderGroup);
   }
 
   /** Group page just older than `beforeSeq` (scroll-up). */
   async getGroupBefore(targetGroupCode: string, beforeSeq: bigint, limit = 50): Promise<RenderGroupMsg[]> {
     const msgs = await this.session.groupMsgs.listBefore(targetGroupCode, beforeSeq, limit);
+    await this.enrichReplyMedia(msgs, 'group');
     return msgs.map(renderGroup);
   }
 
   /** Group page just newer than `afterSeq` (scroll-down / jump context). */
   async getGroupAfter(targetGroupCode: string, afterSeq: bigint, limit = 50): Promise<RenderGroupMsg[]> {
     const msgs = await this.session.groupMsgs.listAfter(targetGroupCode, afterSeq, limit);
+    await this.enrichReplyMedia(msgs, 'group');
     return msgs.map(renderGroup);
   }
 
   /** Re-read group messages with seq >= `sinceSeq` (live refresh). */
   async getGroupFrom(targetGroupCode: string, sinceSeq: bigint, limit = 500): Promise<RenderGroupMsg[]> {
     const msgs = await this.session.groupMsgs.listFrom(targetGroupCode, sinceSeq, limit);
+    await this.enrichReplyMedia(msgs, 'group');
     return msgs.map(renderGroup);
   }
 
@@ -249,6 +278,51 @@ export class MsgService {
     }
   }
 
+  // ---- reply media enrichment ----------------------------------------------
+
+  /**
+   * Back-fill a reply quote's real media element from the 40900 cache.
+   *
+   * QQ NT stores only a "[图片]" / "[视频]" TEXT placeholder in a reply's inline
+   * `origElements` (40800 body) — the quoted message's true media (image token,
+   * md5, CDN urls) lives instead in the 40900 message-cache column as a full
+   * snapshot of the quoted row. So for every reply whose stored origElements
+   * carries NO media element, we look up this message's 40900 cache, find the
+   * cached quoted message (matched by origMsgId, else the first record), and
+   * splice its real elements into origElements — letting the renderer show an
+   * actual thumbnail. Text/@/face replies and replies that already carry media
+   * are left untouched (no lookup).
+   *
+   * Mutates the passed messages in place (before render mapping) and swallows
+   * per-message lookup failures so a bad cache never breaks the page.
+   */
+  private async enrichReplyMedia(
+    msgs: ReplyBearer[],
+    kind: 'c2c' | 'group',
+  ): Promise<void> {
+    const pending = msgs.filter((m) => m.elements.some(isMediaLessReply));
+    if (pending.length === 0) return;
+
+    await Promise.all(
+      pending.map(async (m) => {
+        try {
+          const cache =
+            kind === 'group'
+              ? await this.session.forwardMsgs.listGroupForward(m.msgId)
+              : await this.session.forwardMsgs.listC2cForward(m.msgId);
+          if (cache.length === 0) return;
+          const media = cachedQuotedMedia(cache);
+          if (media.length === 0) return;
+          for (const el of m.elements) {
+            if (isMediaLessReply(el)) (el as ReplyLike).origElements = media;
+          }
+        } catch {
+          /* keep the "[图片]" placeholder on any cache miss / decode error */
+        }
+      }),
+    );
+  }
+
   /** Resolve a peer uid to its indexed partition (sortNo), else fall back to uid. */
   private c2cPartition(targetUid: string): C2cPartition {
     const sortNo = this.session.uidMap.sortNoByUid(targetUid);
@@ -279,4 +353,45 @@ function renderC2c(m: C2cMsg): RenderC2cMsg {
 
 function renderGroup(m: GroupMsg): RenderGroupMsg {
   return { ...m, elements: toRenderElements(m.elements) };
+}
+
+/** A reply element (pre-render): `origElements` holds raw quoted ElementWire. */
+interface ReplyLike {
+  kind?: string;
+  origElements?: unknown[];
+}
+
+/** Raw wire element: an object bearing a numeric `elementType`. */
+function wireType(el: unknown): number {
+  const t = (el as { elementType?: unknown })?.elementType;
+  return typeof t === 'number' ? t : 0;
+}
+
+/**
+ * True for a `reply` element whose stored `origElements` contains no media
+ * element — i.e. only the "[图片]"/"[视频]" text placeholder QQ writes into the
+ * 40800 body. These are the replies worth a 40900-cache lookup.
+ */
+function isMediaLessReply(el: Element): boolean {
+  if ((el as ReplyLike).kind !== 'reply') return false;
+  const orig = (el as ReplyLike).origElements;
+  if (!Array.isArray(orig)) return true;
+  return !orig.some((o) => REPLY_MEDIA_TYPES.has(wireType(o)));
+}
+
+/**
+ * Pick the quoted message's real media-bearing elements out of a 40900 cache.
+ *
+ * A reply's 40900 cache holds exactly ONE record: the quoted message (only
+ * merged-forwards, msgType 8, carry multiple). The reply element's `origMsgId`
+ * is NOT the cached record's snowflake msgId (verified on a live row — they
+ * differ), so we can't match by id; we take the sole record. Returns its raw
+ * wire elements (ready for decodeElement in mapReply), or [] when the cached
+ * record carries no media after all.
+ */
+function cachedQuotedMedia(cache: MsgCacheRecord[]): unknown[] {
+  const record = cache[0];
+  const els = (record as { elements?: unknown[] } | undefined)?.elements;
+  if (!Array.isArray(els)) return [];
+  return els.some((o) => REPLY_MEDIA_TYPES.has(wireType(o))) ? els : [];
 }

--- a/packages/service/src/account/msg.ts
+++ b/packages/service/src/account/msg.ts
@@ -184,12 +184,12 @@ export class MsgService {
   }
 
   /**
-   * Private-chat page just newer than `afterRowId` (rowid order). Export-only
-   * fallback for conversations whose msgSeq is unusable — see
-   * `C2cMsgDb.listAfterRowId`.
+   * Private-chat page of seq-less messages (migration-imported history) just
+   * newer than `afterRowId` (rowid order). Export-only — the seq scan misses
+   * these; see `C2cMsgDb.listSeqlessAfterRowId` and `message_source`.
    */
-  async getC2cAfterRowId(targetUid: string, afterRowId: bigint, limit = 2000): Promise<Array<RenderC2cMsg & { rowId: bigint }>> {
-    const msgs = await this.c2cDbFor(targetUid).listAfterRowId(this.c2cPartition(targetUid), afterRowId, limit);
+  async getC2cSeqlessAfterRowId(targetUid: string, afterRowId: bigint, limit = 2000): Promise<Array<RenderC2cMsg & { rowId: bigint }>> {
+    const msgs = await this.c2cDbFor(targetUid).listSeqlessAfterRowId(this.c2cPartition(targetUid), afterRowId, limit);
     return msgs.map((m) => ({ ...renderC2c(m), rowId: m.rowId }));
   }
 
@@ -220,11 +220,12 @@ export class MsgService {
   }
 
   /**
-   * Group page just newer than `afterRowId` (rowid order). Export-only fallback
-   * for conversations whose msgSeq is unusable — see `GroupMsgDb.listAfterRowId`.
+   * Group page of seq-less messages (migration-imported history) just newer
+   * than `afterRowId` (rowid order). Export-only — the seq scan misses these;
+   * see `GroupMsgDb.listSeqlessAfterRowId` and `message_source`.
    */
-  async getGroupAfterRowId(targetGroupCode: string, afterRowId: bigint, limit = 2000): Promise<Array<RenderGroupMsg & { rowId: bigint }>> {
-    const msgs = await this.session.groupMsgs.listAfterRowId(targetGroupCode, afterRowId, limit);
+  async getGroupSeqlessAfterRowId(targetGroupCode: string, afterRowId: bigint, limit = 2000): Promise<Array<RenderGroupMsg & { rowId: bigint }>> {
+    const msgs = await this.session.groupMsgs.listSeqlessAfterRowId(targetGroupCode, afterRowId, limit);
     return msgs.map((m) => ({ ...renderGroup(m), rowId: m.rowId }));
   }
 

--- a/packages/service/src/account/msg_view.ts
+++ b/packages/service/src/account/msg_view.ts
@@ -153,9 +153,14 @@ export interface RenderPttElement {
     /** File TTL in seconds; CDN expiry ≈ uploadTimestamp + fileTTL. */
     fileTTL: number;
     summary: string[];
-    pttType: number;
+    /** Clip duration in seconds (wire tag 45906) — the render source of truth
+     * for the 时长 label and bubble width; the waveform is decorative. */
+    pttDuration: number;
     voiceChanged: boolean;
-    /** Amplitude envelope: one byte (0–255) per 0.1s; length/10 = duration sec. */
+    /** AI 声聊 marker (wire tag 45915) — true only for AI-voice-chat clips. */
+    isAiVoice?: boolean;
+    /** Amplitude envelope; decorative only. AI 声聊 clips carry a fixed 30-byte
+     * strip, so length/10 is NOT a reliable duration — use pttDuration. */
     waveform: number[];
     // transferState?: number;
     // picTransferState?: number;
@@ -582,8 +587,9 @@ function mapPtt(el: PttElement): RenderPttElement {
       uploadTimestamp: el.uploadTimestamp,
       fileTTL: el.fileTTL,
       summary: el.summary,
-      pttType: el.pttType,
+      pttDuration: el.pttDuration,
       voiceChanged: el.voiceChanged,
+      isAiVoice: el.isAiVoice,
       waveform: Array.from(el.waveform),
       // transferState: el.transferState,
       // picTransferState: el.picTransferState,

--- a/packages/service/src/account/msg_view.ts
+++ b/packages/service/src/account/msg_view.ts
@@ -322,6 +322,7 @@ export interface RenderWalletElement {
     walletDetail?: any;
     walletOrderId?: string;
     walletRedbagType?: number;
+    walletDesignatedUin?: number;
     walletExt?: any;
   };
 }
@@ -799,6 +800,7 @@ function mapWallet(el: WalletElement): RenderWalletElement {
       walletDetail: el.walletDetail,
       walletOrderId: el.walletOrderId,
       walletRedbagType: el.walletRedbagType,
+      walletDesignatedUin: el.walletDesignatedUin,
       walletExt: el.walletExt,
       elementId: el.elementId,
       isSender: el.isSender,

--- a/packages/service/src/account/resource_cleanup.ts
+++ b/packages/service/src/account/resource_cleanup.ts
@@ -1,0 +1,473 @@
+/**
+ * Local resource cleanup for the current QQ account (本地资源整理 → 清理释放).
+ *
+ * Unlike WeQ's own preview cache (see `UserConfigService.clearCache`, which wipes
+ * `%APPDATA%/weq/cache/*`), this service deletes the account's REAL QQ `nt_data`
+ * resource trees — the same files the 本地资源整理 page browses (头像 / 各类表情 /
+ * 图片墙 / QQ空间 / 图片 / 视频 / 语音 / File 目录). Every target is a well-known
+ * sub-directory of `nt_data`; the cleanup is whitelist-gated and each resolved
+ * path is re-checked to sit inside `nt_data` so it can never rm outside the tree
+ * (never `nt_db`, never the `nt_data` root itself, never WeQ's own data).
+ *
+ * Two shapes of deletion:
+ *   - `variant: 'all'`   — remove the whole target dir, then recreate it empty
+ *     (so QQ's next write / our next mkdir is a no-op), mirroring `clearCache`.
+ *   - `variant: 'ori' | 'thumb'` — walk the tree and unlink only files whose path
+ *     runs through an `Ori`/`OriTemp` (原图) or `Thumb` (缩略) segment. Lets the
+ *     user reclaim originals while keeping previews, or vice-versa.
+ *
+ * The 「下载文件」listing (`file_assistant.db` records → arbitrary user download
+ * paths) is deliberately NOT a target, so no cleanup mode can ever touch it.
+ */
+
+import { rmSync, mkdirSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { readdir, stat, unlink } from 'node:fs/promises';
+import { join, resolve, sep } from 'node:path';
+import type { AccountSession } from '@weq/account';
+import type { Platform } from '@weq/platform';
+import { getLogger, logErrorContext } from '../common/logger';
+
+/** How much of a target to delete. */
+export type CleanupVariant = 'all' | 'ori' | 'thumb';
+
+/** Regenerability tier — drives the UI's safe/caution styling. */
+export type CleanupTier = 'safe' | 'caution';
+
+/** One deletable resource, with a directory resolver bound to the platform. */
+interface CleanupTargetDef {
+  id: string;
+  label: string;
+  desc: string;
+  tier: CleanupTier;
+  /** True when the tree has an `Ori`/`Thumb` split (offers 仅原图 / 仅缩略). */
+  hasVariants: boolean;
+  /** Absolute dir for this account, or null when the tree is absent / unresolved. */
+  resolveDir: (platform: Platform, uin: string) => string | null;
+}
+
+/** A count + byte total. */
+export interface CleanupBucket {
+  files: number;
+  bytes: number;
+}
+
+/** One target enriched with its on-disk size (from {@link ResourceCleanupService.listTargets}). */
+export interface CleanupTargetStat {
+  id: string;
+  label: string;
+  desc: string;
+  tier: CleanupTier;
+  hasVariants: boolean;
+  /** False when the tree's directory doesn't exist for this account. */
+  present: boolean;
+  files: number;
+  bytes: number;
+  /** Original files (path under an `Ori`/`OriTemp` dir). */
+  ori: CleanupBucket;
+  /** Thumbnail/preview files (path under a `Thumb` dir). */
+  thumb: CleanupBucket;
+}
+
+/** One instruction: which target, and how much of it to delete. */
+export interface CleanupInstruction {
+  id: string;
+  variant: CleanupVariant;
+}
+
+/** Per-target outcome of a cleanup run. */
+export interface CleanupTargetResult {
+  id: string;
+  variant: CleanupVariant;
+  freedBytes: number;
+  /** Files successfully removed. */
+  removed: number;
+  /** Files that couldn't be removed (e.g. locked by a running QQ). */
+  failed: number;
+}
+
+/** Aggregate outcome of a cleanup run. */
+export interface CleanupResult {
+  freedBytes: number;
+  perTarget: CleanupTargetResult[];
+}
+
+/** `nt_data/avatar` — no dedicated platform helper, derived from `ntDataDir`. */
+function ntDataChild(platform: Platform, uin: string, child: string): string | null {
+  const data = platform.ntDataDir(uin);
+  return data ? join(data, child) : null;
+}
+
+/**
+ * The cleanup registry. Order here is the display order in the 自定义 panel.
+ * `safe` = QQ re-downloads on demand; `caution` = chat content that may be gone
+ * from the server after expiry. 「下载文件」/「系统表情资源」are intentionally absent.
+ */
+const TARGETS: readonly CleanupTargetDef[] = [
+  {
+    id: 'avatar',
+    label: '头像缓存',
+    desc: '好友 / 群 / 陌生人头像，删除后会自动重新下载',
+    tier: 'safe',
+    hasVariants: false,
+    resolveDir: (p, uin) => ntDataChild(p, uin, 'avatar'),
+  },
+  {
+    id: 'marketface',
+    label: '商城表情',
+    desc: '商城下载的贴纸，删除后使用时会自动重新下载',
+    tier: 'safe',
+    hasVariants: false,
+    resolveDir: (p, uin) => p.marketFaceDir(uin),
+  },
+  {
+    id: 'photoWall',
+    label: '图片墙缓存',
+    desc: '群相册 / 图片墙浏览缓存，可随时重新生成',
+    tier: 'safe',
+    hasVariants: false,
+    resolveDir: (p, uin) => ntDataChild(p, uin, 'PhotoWall'),
+  },
+  {
+    id: 'qzone',
+    label: 'QQ空间缓存',
+    desc: 'QQ空间浏览缓存，可随时重新生成',
+    tier: 'safe',
+    hasVariants: false,
+    resolveDir: (p, uin) => ntDataChild(p, uin, 'Qzone'),
+  },
+  {
+    id: 'emojiRelated',
+    label: '关联表情',
+    desc: '关键词联想表情，删除后会自动重新下载',
+    tier: 'safe',
+    hasVariants: false,
+    resolveDir: (p, uin) => p.emojiRelatedDir(uin),
+  },
+  {
+    id: 'pic',
+    label: '聊天图片',
+    desc: '聊天中的图片缓存，服务器过期后可能无法恢复',
+    tier: 'caution',
+    hasVariants: true,
+    resolveDir: (p, uin) => p.picDir(uin),
+  },
+  {
+    id: 'video',
+    label: '聊天视频',
+    desc: '聊天中的视频缓存，服务器过期后可能无法恢复',
+    tier: 'caution',
+    hasVariants: true,
+    resolveDir: (p, uin) => p.videoDir(uin),
+  },
+  {
+    id: 'emojiRecv',
+    label: '收到的表情',
+    desc: '聊天中收到的动态表情缓存',
+    tier: 'caution',
+    hasVariants: true,
+    resolveDir: (p, uin) => p.emojiRecvDir(uin),
+  },
+  {
+    id: 'personalEmoji',
+    label: '我的表情',
+    desc: '你添加 / 收藏的自定义表情',
+    tier: 'caution',
+    hasVariants: true,
+    resolveDir: (p, uin) => p.personalEmojiDir(uin),
+  },
+  {
+    id: 'ptt',
+    label: '聊天语音',
+    desc: '聊天中的语音缓存，服务器过期后可能无法恢复',
+    tier: 'caution',
+    hasVariants: false,
+    resolveDir: (p, uin) => p.pttDir(uin),
+  },
+  {
+    id: 'file',
+    label: 'File 目录',
+    desc: 'nt_data/File 聊天文件缓存（不含你主动下载的文件）',
+    tier: 'caution',
+    hasVariants: false,
+    resolveDir: (p, uin) => p.fileDir(uin),
+  },
+];
+
+/** Hard cap on nodes visited per scan/delete so a pathological tree can't wedge us. */
+const NODE_CAP = 2_000_000;
+
+export class ResourceCleanupService {
+  private readonly logger = getLogger().child({ scope: 'resource-cleanup' });
+
+  constructor(
+    private readonly session: AccountSession,
+    private readonly platform: Platform,
+  ) {}
+
+  private get uin(): string {
+    return this.session.context.uin;
+  }
+
+  /** Absolute `nt_data` root for the account (the containment boundary), or null. */
+  private ntDataRoot(): string | null {
+    return this.platform.ntDataDir(this.uin);
+  }
+
+  /**
+   * Resolve a target's directory AND verify it sits inside `nt_data`. Returns the
+   * absolute path only when it's a real, contained sub-directory — the single
+   * gate every read/delete goes through, so nothing outside `nt_data` is touched.
+   */
+  private safeDir(def: CleanupTargetDef): string | null {
+    const root = this.ntDataRoot();
+    if (!root) return null;
+    const dir = def.resolveDir(this.platform, this.uin);
+    if (!dir) return null;
+    const base = resolve(root);
+    const abs = resolve(dir);
+    // Must be strictly *inside* nt_data (never the root itself).
+    if (abs === base || !abs.startsWith(base + sep)) {
+      this.logger.warn('cleanup target resolved outside nt_data — skipped', {
+        event: 'cleanup-target-out-of-bounds',
+        targetId: def.id,
+        dir: abs,
+        root: base,
+      });
+      return null;
+    }
+    return abs;
+  }
+
+  // ── listing (size scan) ──────────────────────────────────────────────────────
+
+  /**
+   * Per-target on-disk size (files/bytes + ori/thumb split). Slow — every file is
+   * `stat`-ed — so the UI shows a loading state while this runs. Targets whose
+   * directory is absent come back `present: false` with zero counts.
+   */
+  async listTargets(): Promise<CleanupTargetStat[]> {
+    return Promise.all(
+      TARGETS.map(async (def): Promise<CleanupTargetStat> => {
+        const dir = this.safeDir(def);
+        const empty: CleanupTargetStat = {
+          id: def.id,
+          label: def.label,
+          desc: def.desc,
+          tier: def.tier,
+          hasVariants: def.hasVariants,
+          present: false,
+          files: 0,
+          bytes: 0,
+          ori: { files: 0, bytes: 0 },
+          thumb: { files: 0, bytes: 0 },
+        };
+        if (!dir || !existsSync(dir)) return empty;
+        const scan = await this.scan(dir);
+        return { ...empty, present: scan.sawDir, files: scan.files, bytes: scan.bytes, ori: scan.ori, thumb: scan.thumb };
+      }),
+    );
+  }
+
+  /** Iterative DFS size scan with an ori/thumb split (mirrors `analyzeTree`). */
+  private async scan(base: string): Promise<{
+    sawDir: boolean;
+    files: number;
+    bytes: number;
+    ori: CleanupBucket;
+    thumb: CleanupBucket;
+  }> {
+    const out = {
+      sawDir: false,
+      files: 0,
+      bytes: 0,
+      ori: { files: 0, bytes: 0 } as CleanupBucket,
+      thumb: { files: 0, bytes: 0 } as CleanupBucket,
+    };
+    const rootLen = base.length;
+    const stack: string[] = [base];
+    let visited = 0;
+    while (stack.length > 0 && visited < NODE_CAP) {
+      const dir = stack.pop()!;
+      let dirents;
+      try {
+        dirents = await readdir(dir, { withFileTypes: true });
+        out.sawDir = true;
+      } catch {
+        continue;
+      }
+      const files: string[] = [];
+      for (const ent of dirents) {
+        visited += 1;
+        if (ent.isDirectory()) stack.push(join(dir, ent.name));
+        else if (ent.isFile()) files.push(join(dir, ent.name));
+      }
+      await Promise.all(
+        files.map(async (abs) => {
+          let st;
+          try {
+            st = await stat(abs);
+          } catch {
+            return;
+          }
+          out.files += 1;
+          out.bytes += st.size;
+          const bucket = variantBucket(abs.slice(rootLen));
+          if (bucket === 'ori') {
+            out.ori.files += 1;
+            out.ori.bytes += st.size;
+          } else if (bucket === 'thumb') {
+            out.thumb.files += 1;
+            out.thumb.bytes += st.size;
+          }
+        }),
+      );
+    }
+    return out;
+  }
+
+  // ── cleanup (delete) ─────────────────────────────────────────────────────────
+
+  /**
+   * Execute a batch of cleanup instructions. Unknown / out-of-bounds ids are
+   * silently ignored (whitelist gate). Each target is isolated in try/catch so a
+   * locked file (running QQ) or vanished tree can't abort the rest; failures are
+   * counted and returned. Returns total bytes freed + per-target results.
+   */
+  async cleanup(instructions: CleanupInstruction[]): Promise<CleanupResult> {
+    const perTarget: CleanupTargetResult[] = [];
+    let freedBytes = 0;
+
+    for (const ins of instructions) {
+      const def = TARGETS.find((t) => t.id === ins.id);
+      if (!def) continue; // not on the whitelist — ignore
+      const dir = this.safeDir(def);
+      if (!dir || !existsSync(dir)) continue;
+
+      // A variant delete only makes sense for split trees; for non-variant
+      // targets any variant means "the whole thing".
+      const variant: CleanupVariant = def.hasVariants ? ins.variant : 'all';
+
+      try {
+        const res =
+          variant === 'all'
+            ? this.removeDirWhole(dir)
+            : await this.removeByVariant(dir, variant);
+        freedBytes += res.freedBytes;
+        perTarget.push({ id: def.id, variant, ...res });
+      } catch (error) {
+        this.logger.error('cleanup target failed', {
+          event: 'cleanup-target-failed',
+          targetId: def.id,
+          variant,
+          dir,
+          ...logErrorContext(error),
+        });
+        perTarget.push({ id: def.id, variant, freedBytes: 0, removed: 0, failed: 1 });
+      }
+    }
+
+    this.logger.info('cleaned nt_data resources', {
+      event: 'clear-nt-data',
+      uin: this.uin,
+      freedBytes,
+      targets: perTarget.map((t) => `${t.id}:${t.variant}`),
+    });
+    return { freedBytes, perTarget };
+  }
+
+  /** Remove a whole target dir, then recreate it empty (mirrors `clearCache`). */
+  private removeDirWhole(dir: string): { freedBytes: number; removed: number; failed: number } {
+    const freedBytes = dirSizeBytesSync(dir);
+    rmSync(dir, { recursive: true, force: true });
+    mkdirSync(dir, { recursive: true });
+    // Whole-dir remove doesn't track per-file counts; report a coarse success.
+    return { freedBytes, removed: 1, failed: 0 };
+  }
+
+  /** Walk the tree and unlink only files under the requested variant segment. */
+  private async removeByVariant(
+    base: string,
+    variant: 'ori' | 'thumb',
+  ): Promise<{ freedBytes: number; removed: number; failed: number }> {
+    const rootLen = base.length;
+    const stack: string[] = [base];
+    let freedBytes = 0;
+    let removed = 0;
+    let failed = 0;
+    let visited = 0;
+
+    while (stack.length > 0 && visited < NODE_CAP) {
+      const dir = stack.pop()!;
+      let dirents;
+      try {
+        dirents = await readdir(dir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      const files: string[] = [];
+      for (const ent of dirents) {
+        visited += 1;
+        if (ent.isDirectory()) stack.push(join(dir, ent.name));
+        else if (ent.isFile()) files.push(join(dir, ent.name));
+      }
+      await Promise.all(
+        files.map(async (abs) => {
+          if (variantBucket(abs.slice(rootLen)) !== variant) return;
+          let size = 0;
+          try {
+            size = (await stat(abs)).size;
+          } catch {
+            return; // vanished
+          }
+          try {
+            await unlink(abs);
+            freedBytes += size;
+            removed += 1;
+          } catch {
+            failed += 1; // locked by a running QQ, etc.
+          }
+        }),
+      );
+    }
+    return { freedBytes, removed, failed };
+  }
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/** Classify a file by its path into the ori / thumb / other bucket (same rule as media_resource). */
+function variantBucket(relPath: string): 'ori' | 'thumb' | 'other' {
+  const segs = relPath.split(/[/\\]/);
+  if (segs.includes('Thumb')) return 'thumb';
+  if (segs.includes('Ori') || segs.includes('OriTemp')) return 'ori';
+  return 'other';
+}
+
+/** Synchronous recursive byte size with a node-visit cap. Missing dirs → 0. */
+function dirSizeBytesSync(root: string, cap = NODE_CAP): number {
+  let total = 0;
+  let visited = 0;
+  const stack: string[] = [root];
+  while (stack.length > 0 && visited < cap) {
+    const dir = stack.pop()!;
+    let dirents;
+    try {
+      dirents = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const ent of dirents) {
+      visited += 1;
+      const abs = join(dir, ent.name);
+      if (ent.isDirectory()) stack.push(abs);
+      else if (ent.isFile()) {
+        try {
+          total += statSync(abs).size;
+        } catch {
+          /* vanished */
+        }
+      }
+    }
+  }
+  return total;
+}

--- a/packages/service/src/bootstrap/user_config.ts
+++ b/packages/service/src/bootstrap/user_config.ts
@@ -16,7 +16,16 @@
  * track those files — TTL / pruning belongs in whoever wrote them.
  */
 
-import { mkdirSync, readFileSync, writeFileSync, readdirSync, unlinkSync } from 'node:fs';
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  readdirSync,
+  unlinkSync,
+  statSync,
+  rmSync,
+  existsSync,
+} from 'node:fs';
 import { join, basename } from 'node:path';
 import type { Platform } from '@weq/platform';
 import type { AgentLabProviderConfig, TtsProviderConfig } from '@weq/agentlab';
@@ -415,4 +424,111 @@ export class UserConfigService {
       dir: dir && dir.trim() ? dir : null,
     });
   }
+
+  /**
+   * WeQ 缓存清理.
+   *
+   * The `<cacheBase>/<category>/` layout is written by various callers
+   * (avatars, media previews, 商城表情, 语音转录). These four categories are
+   * pure caches — every file is re-downloadable / re-generatable on demand,
+   * so wiping them only costs a re-fetch. We deliberately DO NOT expose
+   * `agentlab`（克隆体运行数据）, `weq-assistant`（推文/周报快照）or
+   * `export`（导出产物）here: those hold user-generated content, not cache.
+   */
+  private static readonly CLEARABLE_CACHE_CATEGORIES: ReadonlyArray<{
+    id: string;
+    label: string;
+  }> = [
+    { id: 'avatar', label: '头像缓存' },
+    { id: 'media', label: '图片/视频缓存' },
+    { id: 'marketface', label: '商城表情缓存' },
+    { id: 'voice', label: '语音转录缓存' },
+  ];
+
+  /** Per-category on-disk size (bytes) for the clearable cache categories. */
+  listClearableCache(): Array<{ id: string; label: string; bytes: number }> {
+    const base = this.cacheBaseDir();
+    return UserConfigService.CLEARABLE_CACHE_CATEGORIES.map(({ id, label }) => ({
+      id,
+      label,
+      bytes: dirSizeBytes(join(base, id)),
+    }));
+  }
+
+  /**
+   * Delete the given clearable cache categories (or all of them when `ids` is
+   * omitted). Unknown / non-clearable ids are ignored — we never rm outside
+   * the whitelist, so this can't touch agentlab / export / config / logs.
+   * Returns the number of bytes freed.
+   */
+  clearCache(ids?: string[]): { freedBytes: number; cleared: string[] } {
+    const base = this.cacheBaseDir();
+    const allowed = new Set(
+      UserConfigService.CLEARABLE_CACHE_CATEGORIES.map((c) => c.id),
+    );
+    const targets = (ids && ids.length > 0 ? ids : [...allowed]).filter((id) =>
+      allowed.has(id),
+    );
+    let freedBytes = 0;
+    const cleared: string[] = [];
+    for (const id of targets) {
+      const dir = join(base, id);
+      if (!existsSync(dir)) continue;
+      freedBytes += dirSizeBytes(dir);
+      try {
+        // Remove the category folder wholesale, then recreate it empty so the
+        // next writer's mkdir -p is a no-op and nothing breaks mid-session.
+        rmSync(dir, { recursive: true, force: true });
+        mkdirSync(dir, { recursive: true });
+        cleared.push(id);
+      } catch (error) {
+        this.logger.error('failed to clear cache category', {
+          event: 'clear-cache-failed',
+          category: id,
+          dir,
+          ...logErrorContext(error),
+        });
+      }
+    }
+    this.logger.info('cleared weq cache', {
+      event: 'clear-cache',
+      cleared,
+      freedBytes,
+    });
+    return { freedBytes, cleared };
+  }
+}
+
+/**
+ * Recursive directory byte size with a hard node-visit cap so a pathological
+ * tree (the avatar/media caches can hold tens of thousands of tiny files)
+ * can't wedge the caller. Missing dirs return 0.
+ */
+function dirSizeBytes(root: string, cap = 500_000): number {
+  let total = 0;
+  let visited = 0;
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop() as string;
+    let dirents: import('node:fs').Dirent[];
+    try {
+      dirents = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const d of dirents) {
+      if (++visited > cap) return total;
+      const full = join(dir, d.name);
+      if (d.isDirectory()) {
+        stack.push(full);
+      } else if (d.isFile()) {
+        try {
+          total += statSync(full).size;
+        } catch {
+          /* skip */
+        }
+      }
+    }
+  }
+  return total;
 }

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -198,6 +198,16 @@ export type {
   ResourceBucket,
   ResourceStat,
 } from './account/media_resource';
+export { ResourceCleanupService } from './account/resource_cleanup';
+export type {
+  CleanupVariant,
+  CleanupTier,
+  CleanupBucket,
+  CleanupTargetStat,
+  CleanupInstruction,
+  CleanupTargetResult,
+  CleanupResult,
+} from './account/resource_cleanup';
 export {
   ACCOUNT_HEALTH_DATABASES,
   checkAccountDatabaseHealth,

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -137,13 +137,14 @@ export type {
   TableRowsResult,
   QueryResult,
 } from './account/db_explorer';
-export { AvatarResourceService, AVATAR_SCOPES } from './account/avatar_resource';
+export { AvatarResourceService, AVATAR_SCOPES, avatarHashForUid } from './account/avatar_resource';
 export type {
   AvatarScope,
   AvatarVariant,
   AvatarScopeInfo,
   AvatarEntry,
   AvatarPage,
+  AvatarPathProbe,
 } from './account/avatar_resource';
 export { SysEmojiResourceService } from './account/sys_emoji_resource';
 export type {


### PR DESCRIPTION
- feat: avatar path 本地计算。 告别全量cdn请求： <del>三重md5，太伟大了claude</del>
- feat: 群友资料卡片
- feat: 解析会话的notify等级： 是否开启免打扰
- feat: 回复消息从40900列获取原消息媒体信息
- feat: 解析特殊对话提醒： 包括 @ @所有人 新文件 特别关心
- feat: 本地资源清理功能
- feat: 灯箱大图的放缩和拖动
- feat: 群聊更多的红包类型解析：拼手气，专属 <del>以及领取情况</del>
- feat: AI语音， 普通语音， 变声， 录音  四种类型的判断和渲染
- [ ] feat: 导出机器人的设置页面webui
- feat: 导出联系人
- fix: 混合seq类型无法导出
- fix: 口令红包误用封面的bug
- fix: 破坏的contact导致导出异常
- fix: 本地资源整理渲染大小误用字节数
- fix: AI声聊silk解码失败的bug
- fix: 合并转发消息的is_sender混乱问题
- fix: 群公告ark卡片的base64编码渲染问题
- fix: 群聊分析群成员查询不更新的问题
- fix: 回复消息mutli消息类型无法正确渲染：包括text at face pic
- refactor: 优化头像获取路径
- [ ] refactor:  agent页面重构